### PR TITLE
Add expandable floating node palette

### DIFF
--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -17,19 +17,11 @@ export default function NodePalette() {
 
   return (
     <div className="palette-wrapper">
-      {!open && (
-        <button className="palette-toggle" onClick={() => setOpen(true)}>
-          Nodes
-        </button>
-      )}
+      <button className="palette-toggle" onClick={() => setOpen(!open)}>
+        {open ? '✕' : 'Nodes'}
+      </button>
       {open && (
         <aside className="palette palette-floating">
-          <button
-            className="palette-close"
-            onClick={() => setOpen(false)}
-          >
-            ✕
-          </button>
           <input
             placeholder="Search..."
             value={query}

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -17,8 +17,13 @@ export default function NodePalette() {
 
   return (
     <div className="palette-wrapper">
-      <button className="palette-toggle" onClick={() => setOpen(!open)}>
-        {open ? '✕' : 'Nodes'}
+      <button
+        type="button"
+        className="palette-toggle"
+        aria-label={open ? 'Close node list' : 'Add node'}
+        onClick={() => setOpen(!open)}
+      >
+        {open ? '✕' : '➕'}
       </button>
       {open && (
         <aside className="palette palette-floating">

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -25,25 +25,25 @@ export default function NodePalette() {
       >
         {open ? (
           <svg
-            width="14"
-            height="14"
+            width="16"
+            height="16"
             viewBox="0 0 12 12"
             aria-hidden="true"
           >
             <line
-              x1="2"
-              y1="2"
-              x2="10"
-              y2="10"
+              x1="1"
+              y1="1"
+              x2="11"
+              y2="11"
               stroke="currentColor"
               strokeWidth="2"
               strokeLinecap="round"
             />
             <line
-              x1="10"
-              y1="2"
-              x2="2"
-              y2="10"
+              x1="11"
+              y1="1"
+              x2="1"
+              y2="11"
               stroke="currentColor"
               strokeWidth="2"
               strokeLinecap="round"
@@ -51,25 +51,25 @@ export default function NodePalette() {
           </svg>
         ) : (
           <svg
-            width="14"
-            height="14"
+            width="16"
+            height="16"
             viewBox="0 0 12 12"
             aria-hidden="true"
           >
-            <line
-              x1="6"
-              y1="1"
-              x2="6"
-              y2="11"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-            />
             <line
               x1="1"
               y1="6"
               x2="11"
               y2="6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <line
+              x1="6"
+              y1="1"
+              x2="6"
+              y2="11"
               stroke="currentColor"
               strokeWidth="2"
               strokeLinecap="round"

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -1,12 +1,10 @@
 import { useMemo, useState } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
-import type { NodeType } from '../types';
-import { clsx } from 'clsx';
 
 export default function NodePalette() {
   const nodeTypes = useWorkflowStore((s) => s.nodeTypes);
-  const addNode = useWorkflowStore((s) => s.addNode);
   const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
 
   const filtered = useMemo(() => {
     const q = query.toLowerCase();
@@ -18,26 +16,41 @@ export default function NodePalette() {
   }, [nodeTypes, query]);
 
   return (
-    <aside className="palette">
-      <input
-        placeholder="Search..."
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
-      <ul>
-        {filtered.map((nt) => (
-          <li
-            key={nt.id}
-            draggable
-            onDragStart={(e) => {
-              e.dataTransfer.setData('application/x-node-type', nt.id);
-            }}
+    <div className="palette-wrapper">
+      {!open && (
+        <button className="palette-toggle" onClick={() => setOpen(true)}>
+          Nodes
+        </button>
+      )}
+      {open && (
+        <aside className="palette palette-floating">
+          <button
+            className="palette-close"
+            onClick={() => setOpen(false)}
           >
-            {nt.icon && <img src={nt.icon} alt="" />}
-            {nt.name}
-          </li>
-        ))}
-      </ul>
-    </aside>
+            ✕
+          </button>
+          <input
+            placeholder="Search..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+          <ul>
+            {filtered.map((nt) => (
+              <li
+                key={nt.id}
+                draggable
+                onDragStart={(e) => {
+                  e.dataTransfer.setData('application/x-node-type', nt.id);
+                }}
+              >
+                {nt.icon && <img src={nt.icon} alt="" />}
+                {nt.name}
+              </li>
+            ))}
+          </ul>
+        </aside>
+      )}
+    </div>
   );
 }

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -23,7 +23,59 @@ export default function NodePalette() {
         aria-label={open ? 'Close node list' : 'Add node'}
         onClick={() => setOpen(!open)}
       >
-        {open ? '✕' : '➕'}
+        {open ? (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 12 12"
+            aria-hidden="true"
+          >
+            <line
+              x1="2"
+              y1="2"
+              x2="10"
+              y2="10"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <line
+              x1="10"
+              y1="2"
+              x2="2"
+              y2="10"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        ) : (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 12 12"
+            aria-hidden="true"
+          >
+            <line
+              x1="6"
+              y1="1"
+              x2="6"
+              y2="11"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+            <line
+              x1="1"
+              y1="6"
+              x2="11"
+              y2="6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        )}
       </button>
       {open && (
         <aside className="palette palette-floating">

--- a/src/theme.css
+++ b/src/theme.css
@@ -32,8 +32,8 @@
 }
 .palette-toggle {
   position: absolute;
-  top: 10px;
-  left: 10px;
+  top: 20px;
+  left: 20px;
   z-index: 15;
   background: var(--accent);
   color: #fff;
@@ -48,8 +48,8 @@
 }
 .palette-floating {
   position: absolute;
-  top: 52px;
-  left: 10px;
+  top: 62px;
+  left: 20px;
   z-index: 10;
   background: var(--bg);
   border: 1px solid #6663;

--- a/src/theme.css
+++ b/src/theme.css
@@ -26,6 +26,42 @@
   padding: 0.5rem;
   overflow: auto;
 }
+.palette-wrapper {
+  position: relative;
+  width: 0;
+}
+.palette-toggle {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 5;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+.palette-floating {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
+  background: var(--bg);
+  border: 1px solid #6663;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  max-height: 80vh;
+  width: 240px;
+}
+.palette-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: none;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+}
 .canvas { flex: 1; }
 .props {
   width: 260px;

--- a/src/theme.css
+++ b/src/theme.css
@@ -38,7 +38,7 @@
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 4px;
+  border-radius: 8px;
   padding: 2px 6px;
   cursor: pointer;
 }
@@ -53,13 +53,13 @@
   max-height: calc(80vh - 46px);
   width: 240px;
   padding: 0.5rem;
-  border-radius: 6px;
+  border-radius: 10px;
 }
 .palette-floating input {
   margin-bottom: 0.5rem;
   padding: 2px 4px;
   border: 1px solid #6663;
-  border-radius: 4px;
+  border-radius: 8px;
 }
 .canvas { flex: 1; }
 .props {

--- a/src/theme.css
+++ b/src/theme.css
@@ -44,15 +44,15 @@
 }
 .palette-floating {
   position: absolute;
-  top: 10px;
+  top: 46px;
   left: 10px;
   z-index: 10;
-  padding-top: 32px;
   background: var(--bg);
   border: 1px solid #6663;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-  max-height: 80vh;
+  max-height: calc(80vh - 46px);
   width: 240px;
+  padding: 0.5rem;
 }
 .canvas { flex: 1; }
 .props {

--- a/src/theme.css
+++ b/src/theme.css
@@ -39,12 +39,16 @@
   color: #fff;
   border: none;
   border-radius: 8px;
-  padding: 2px 6px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
 }
 .palette-floating {
   position: absolute;
-  top: 46px;
+  top: 52px;
   left: 10px;
   z-index: 10;
   background: var(--bg);

--- a/src/theme.css
+++ b/src/theme.css
@@ -53,6 +53,13 @@
   max-height: calc(80vh - 46px);
   width: 240px;
   padding: 0.5rem;
+  border-radius: 6px;
+}
+.palette-floating input {
+  margin-bottom: 0.5rem;
+  padding: 2px 4px;
+  border: 1px solid #6663;
+  border-radius: 4px;
 }
 .canvas { flex: 1; }
 .props {

--- a/src/theme.css
+++ b/src/theme.css
@@ -34,7 +34,7 @@
   position: absolute;
   top: 10px;
   left: 10px;
-  z-index: 5;
+  z-index: 15;
   background: var(--accent);
   color: #fff;
   border: none;
@@ -47,20 +47,12 @@
   top: 10px;
   left: 10px;
   z-index: 10;
+  padding-top: 32px;
   background: var(--bg);
   border: 1px solid #6663;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
   max-height: 80vh;
   width: 240px;
-}
-.palette-close {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  background: none;
-  border: none;
-  color: var(--fg);
-  cursor: pointer;
 }
 .canvas { flex: 1; }
 .props {


### PR DESCRIPTION
## Summary
- convert `NodePalette` sidebar to expandable floating menu
- add toggle button and close controls
- style palette overlay and button in `theme.css`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68473c5fb3888327ba54906915929909