### PR TITLE
Move validate control beside palette toggle

### DIFF
--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -85,9 +85,9 @@ export default function NodePalette() {
           }
         }}
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+        <svg width="16" height="16" viewBox="0 0 12 12" aria-hidden="true">
           <polyline
-            points="3 9 7 13 13 5"
+            points="2 7 5 10 10 3"
             fill="none"
             stroke="currentColor"
             strokeWidth="2"

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -72,6 +72,30 @@ export default function NodePalette() {
           </svg>
         )}
       </button>
+      <button
+        type="button"
+        className="palette-toggle validate-toggle"
+        aria-label="Validate workflow"
+        onClick={() => {
+          const err = validateWorkflow(nodes, edges, nodeTypes, hierarchy);
+          if (err) {
+            setToast(err, 'error');
+          } else {
+            setToast('Workflow valid', 'success');
+          }
+        }}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
+          <polyline
+            points="3 9 7 13 13 5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
       {open && (
         <aside className="palette palette-floating">
           <input
@@ -93,19 +117,6 @@ export default function NodePalette() {
               </li>
             ))}
           </ul>
-          <button
-            className="validate-btn"
-            onClick={() => {
-              const err = validateWorkflow(nodes, edges, nodeTypes, hierarchy);
-              if (err) {
-                setToast(err, 'error');
-              } else {
-                setToast('Workflow valid', 'success');
-              }
-            }}
-          >
-            Validate
-          </button>
         </aside>
       )}
     </div>

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -87,7 +87,7 @@ export default function NodePalette() {
       >
         <svg width="16" height="16" viewBox="0 0 12 12" aria-hidden="true">
           <polyline
-            points="2 7 5 10 10 3"
+            points="1 7 5 11 11 1"
             fill="none"
             stroke="currentColor"
             strokeWidth="2"

--- a/src/theme.css
+++ b/src/theme.css
@@ -46,6 +46,9 @@
   justify-content: center;
   cursor: pointer;
 }
+.validate-toggle {
+  left: 60px;
+}
 .palette-floating {
   position: absolute;
   top: 62px;
@@ -179,17 +182,6 @@
   cursor: pointer;
 }
 
-.validate-btn {
-  background: var(--accent);
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-size: 12px;
-  padding: 4px;
-  width: 100%;
-  margin-top: 0.5rem;
-  cursor: pointer;
-}
 
 /* Properties panel fields */
 .field-label {


### PR DESCRIPTION
## Summary
- move validation button outside of the palette list
- add icon-only style matching the palette toggle
- remove unused validate button style

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_684763b55e00832792a4e73ebdbb147a