### PR TITLE
Add workflow persistence with autosave

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import NodePalette from './components/NodePalette';
 import EditorCanvas from './components/EditorCanvas';
 import PropertiesPanel from './components/PropertiesPanel';
 import ErrorToast from './components/ErrorToast';
+import WorkflowManager from './components/WorkflowManager';
 import clsx from 'clsx';
 
 export default function App() {
@@ -19,6 +20,7 @@ export default function App() {
 
   return (
     <div className={clsx('app', theme)}>
+      <WorkflowManager />
       <NodePalette />
       <EditorCanvas />
       <PropertiesPanel />

--- a/src/components/WorkflowManager.tsx
+++ b/src/components/WorkflowManager.tsx
@@ -6,6 +6,7 @@ export default function WorkflowManager() {
   const refresh = useWorkflowStore((s) => s.refreshSavedWorkflows);
   const save = useWorkflowStore((s) => s.saveWorkflow);
   const load = useWorkflowStore((s) => s.loadWorkflow);
+  const remove = useWorkflowStore((s) => s.deleteWorkflow);
   const current = useWorkflowStore((s) => s.workflowName);
   const dirty = useWorkflowStore((s) => s.dirty);
   const nodes = useWorkflowStore((s) => s.nodes);
@@ -31,6 +32,12 @@ export default function WorkflowManager() {
     if (name) save(name);
   };
 
+  const handleDelete = () => {
+    if (current && confirm(`Delete workflow "${current}"?`)) {
+      remove(current);
+    }
+  };
+
   return (
     <div className="workflow-bar">
       <select
@@ -44,6 +51,7 @@ export default function WorkflowManager() {
         ))}
       </select>
       <button onClick={handleSaveAs}>Save As</button>
+      <button className="delete" onClick={handleDelete}>Delete</button>
       {dirty && <span className="unsaved">*</span>}
     </div>
   );

--- a/src/components/WorkflowManager.tsx
+++ b/src/components/WorkflowManager.tsx
@@ -13,6 +13,10 @@ export default function WorkflowManager() {
   const edges = useWorkflowStore((s) => s.edges);
   const setToast = useWorkflowStore((s) => s.setToast);
 
+  const [showSave, setShowSave] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const [nameInput, setNameInput] = useState(current);
+
   useEffect(() => {
     refresh();
   }, [refresh]);
@@ -28,31 +32,76 @@ export default function WorkflowManager() {
   }, [nodes, edges, current, dirty, save, setToast]);
 
   const handleSaveAs = () => {
-    const name = prompt('Workflow name', current);
-    if (name) save(name);
+    setNameInput(current);
+    setShowSave(true);
   };
 
   const handleDelete = () => {
-    if (current && confirm(`Delete workflow "${current}"?`)) {
-      remove(current);
+    if (current) {
+      setShowDelete(true);
     }
   };
 
   return (
-    <div className="workflow-bar">
-      <select
-        value={current}
-        onChange={(e) => load(e.target.value)}
-      >
-        {names.map((n) => (
-          <option key={n} value={n}>
-            {n}
-          </option>
-        ))}
-      </select>
-      <button onClick={handleSaveAs}>Save As</button>
-      <button className="delete" onClick={handleDelete}>Delete</button>
-      {dirty && <span className="unsaved">*</span>}
-    </div>
+    <>
+      <div className="workflow-bar">
+        <select value={current} onChange={(e) => load(e.target.value)}>
+          {names.map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+        <button onClick={handleSaveAs}>Save As</button>
+        <button className="delete" onClick={handleDelete}>Delete</button>
+        {dirty && <span className="unsaved">*</span>}
+      </div>
+
+      {showSave && (
+        <>
+          <div className="modal-backdrop" onClick={() => setShowSave(false)} />
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <h3>Name Workflow</h3>
+            <input
+              type="text"
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+            />
+            <div className="modal-buttons">
+              <button onClick={() => setShowSave(false)}>Cancel</button>
+              <button
+                onClick={() => {
+                  save(nameInput);
+                  setShowSave(false);
+                }}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {showDelete && (
+        <>
+          <div className="modal-backdrop" onClick={() => setShowDelete(false)} />
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <p>Delete workflow "{current}"?</p>
+            <div className="modal-buttons">
+              <button onClick={() => setShowDelete(false)}>Cancel</button>
+              <button
+                className="delete"
+                onClick={() => {
+                  remove(current);
+                  setShowDelete(false);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </>
+      )}
+    </>
   );
 }

--- a/src/components/WorkflowManager.tsx
+++ b/src/components/WorkflowManager.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useWorkflowStore } from '../store/workflowStore';
+
+export default function WorkflowManager() {
+  const names = useWorkflowStore((s) => s.savedWorkflows);
+  const refresh = useWorkflowStore((s) => s.refreshSavedWorkflows);
+  const save = useWorkflowStore((s) => s.saveWorkflow);
+  const load = useWorkflowStore((s) => s.loadWorkflow);
+  const current = useWorkflowStore((s) => s.workflowName);
+  const dirty = useWorkflowStore((s) => s.dirty);
+  const nodes = useWorkflowStore((s) => s.nodes);
+  const edges = useWorkflowStore((s) => s.edges);
+  const setToast = useWorkflowStore((s) => s.setToast);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (current && dirty) {
+      try {
+        save(current);
+      } catch {
+        setToast('Auto-save failed');
+      }
+    }
+  }, [nodes, edges, current, dirty, save, setToast]);
+
+  const handleSaveAs = () => {
+    const name = prompt('Workflow name', current);
+    if (name) save(name);
+  };
+
+  return (
+    <div className="workflow-bar">
+      <select
+        value={current}
+        onChange={(e) => load(e.target.value)}
+      >
+        {names.map((n) => (
+          <option key={n} value={n}>
+            {n}
+          </option>
+        ))}
+      </select>
+      <button onClick={handleSaveAs}>Save As</button>
+      {dirty && <span className="unsaved">*</span>}
+    </div>
+  );
+}

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -26,6 +26,7 @@ interface WorkflowState {
   refreshSavedWorkflows: () => void;
   saveWorkflow: (name: string) => void;
   loadWorkflow: (name: string) => void;
+  deleteWorkflow: (name: string) => void;
 
   loadDefinitions: (json: {
     types: Record<string, string | null>;
@@ -114,6 +115,23 @@ export const useWorkflowStore = create<WorkflowState>()(
         } catch {
           /* ignore parse errors */
         }
+      }),
+
+    deleteWorkflow: (name) =>
+      set((s) => {
+        localStorage.removeItem(`workflow.${name}`);
+        const list = localStorage.getItem('workflows');
+        const names = list ? JSON.parse(list) : [];
+        const index = names.indexOf(name);
+        if (index !== -1) {
+          names.splice(index, 1);
+          localStorage.setItem('workflows', JSON.stringify(names));
+        }
+        if (s.workflowName === name) {
+          s.workflowName = 'autosave';
+          s.dirty = true;
+        }
+        s.savedWorkflows = names;
       }),
 
     loadDefinitions: (json) =>

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -18,8 +18,14 @@ interface WorkflowState {
   theme: 'light' | 'dark';
   undoStack: unknown[];
   redoStack: unknown[];
+  workflowName: string;
+  dirty: boolean;
+  savedWorkflows: string[];
   toast: { message: string; type: 'error' | 'success' } | null;
   setToast: (msg: string, type?: 'error' | 'success') => void;
+  refreshSavedWorkflows: () => void;
+  saveWorkflow: (name: string) => void;
+  loadWorkflow: (name: string) => void;
 
   loadDefinitions: (json: {
     types: Record<string, string | null>;
@@ -58,12 +64,56 @@ export const useWorkflowStore = create<WorkflowState>()(
         : 'light'),
     undoStack: [],
     redoStack: [],
+    workflowName: 'autosave',
+    dirty: false,
+    savedWorkflows: [],
 
     setToast: (msg, type = 'error') =>
       set((s) => {
         s.toast = { message: msg, type };
         /* auto-clear after 3 s */
         setTimeout(() => set((st) => void (st.toast = null)), 3000);
+      }),
+
+    refreshSavedWorkflows: () =>
+      set((s) => {
+        const list = localStorage.getItem('workflows');
+        s.savedWorkflows = list ? JSON.parse(list) : [];
+      }),
+
+    saveWorkflow: (name) =>
+      set((s) => {
+        localStorage.setItem(
+          `workflow.${name}`,
+          JSON.stringify({ nodes: s.nodes, edges: s.edges })
+        );
+        const list = localStorage.getItem('workflows');
+        const names = list ? JSON.parse(list) : [];
+        if (!names.includes(name)) {
+          names.push(name);
+          localStorage.setItem('workflows', JSON.stringify(names));
+        }
+        s.workflowName = name;
+        s.dirty = false;
+        s.savedWorkflows = names;
+      }),
+
+    loadWorkflow: (name) =>
+      set((s) => {
+        const data = localStorage.getItem(`workflow.${name}`);
+        if (!data) return;
+        try {
+          const parsed = JSON.parse(data) as {
+            nodes: Record<string, NodeInstance>;
+            edges: EdgeInstance[];
+          };
+          s.nodes = parsed.nodes;
+          s.edges = parsed.edges;
+          s.workflowName = name;
+          s.dirty = false;
+        } catch {
+          /* ignore parse errors */
+        }
       }),
 
     loadDefinitions: (json) =>
@@ -81,6 +131,7 @@ export const useWorkflowStore = create<WorkflowState>()(
           position,
           fields: {}
         };
+        s.dirty = true;
       }),
 
     duplicateNode: (origId) =>
@@ -94,6 +145,7 @@ export const useWorkflowStore = create<WorkflowState>()(
           position: { x: orig.position.x + 20, y: orig.position.y + 20 },
           fields: { ...orig.fields }
         };
+        s.dirty = true;
       }),
 
     removeNode: (id) =>
@@ -102,16 +154,19 @@ export const useWorkflowStore = create<WorkflowState>()(
         s.edges = s.edges.filter(
           (e) => e.from.uuid !== id && e.to.uuid !== id
         );
+        s.dirty = true;
       }),
 
     addEdge: (edge) =>
       set((s) => {
         s.edges.push(edge);
+        s.dirty = true;
       }),
 
     removeEdge: (id) =>
       set((s) => {
         s.edges = s.edges.filter((e) => e.id !== id);
+        s.dirty = true;
       }),
 
     openContextMenu: (menu) =>
@@ -144,6 +199,7 @@ export const useWorkflowStore = create<WorkflowState>()(
       set((s) => {
         if (s.nodes[uuid]) {
           s.nodes[uuid].fields[fieldId] = value;
+          s.dirty = true;
         }
       }),
 
@@ -151,6 +207,7 @@ export const useWorkflowStore = create<WorkflowState>()(
       set((s) => {
         if (s.nodes[uuid]) {
           s.nodes[uuid].position = pos;
+          s.dirty = true;
         }
       })
   }))

--- a/src/theme.css
+++ b/src/theme.css
@@ -318,6 +318,9 @@
   padding: 2px 6px;
   cursor: pointer;
 }
+.workflow-bar button.delete {
+  background: #d55;
+}
 .unsaved {
   color: var(--accent);
   font-weight: bold;

--- a/src/theme.css
+++ b/src/theme.css
@@ -294,3 +294,31 @@
   --xy-controls-button-color-hover: var(--accent);
   --xy-controls-button-border-color: var(--accent);
 }
+
+/* Workflow manager bar */
+.workflow-bar {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+  z-index: 20;
+}
+.workflow-bar select {
+  padding: 2px 4px;
+  border: 1px solid #6663;
+  border-radius: 4px;
+}
+.workflow-bar button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+.unsaved {
+  color: var(--accent);
+  font-weight: bold;
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -167,6 +167,27 @@
   z-index: 10;
   min-width: 240px;
 }
+.modal input[type="text"] {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 1rem;
+}
+.modal button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+.modal button.delete {
+  background: #d55;
+}
 
 /* Edit button row */
 .edit-row {


### PR DESCRIPTION
## Summary
- keep workflow nodes in browser localStorage
- expose saved workflows via new `WorkflowManager` component
- mark store dirty when workflow changes
- style workflow manager bar and unsaved indicator

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_68476a98bc788327a8cf99e75091d7ec