### PR TITLE
Add divider styling and workflow search

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,7 +1,9 @@
 export default function SettingsPage() {
   return (
     <main className="main">
-      <h2>Settings</h2>
+      <div className="page-header">
+        <h2>Settings</h2>
+      </div>
     </main>
   );
 }

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -1,7 +1,9 @@
 export default function ToolsPage() {
   return (
     <main className="main">
-      <h2>Tools</h2>
+      <div className="page-header">
+        <h2>Tools</h2>
+      </div>
     </main>
   );
 }

--- a/src/components/WorkflowList.tsx
+++ b/src/components/WorkflowList.tsx
@@ -61,6 +61,7 @@ export default function WorkflowList({
               strokeLinecap="round"
             />
           </svg>
+          <span className="create-label">New</span>
         </button>
       </div>
       <ul>

--- a/src/components/WorkflowList.tsx
+++ b/src/components/WorkflowList.tsx
@@ -52,7 +52,7 @@ export default function WorkflowList({
           </svg>
           <input
             className="workflow-search"
-            placeholder="Search workflows"
+            placeholder="Search..."
             value={query}
             onChange={e => setQuery(e.target.value)}
           />

--- a/src/components/WorkflowList.tsx
+++ b/src/components/WorkflowList.tsx
@@ -16,12 +16,17 @@ export default function WorkflowList({
 
   const [renaming, setRenaming] = useState<string | null>(null);
   const [newName, setNewName] = useState('');
+  const [query, setQuery] = useState('');
 
   useEffect(() => { refresh(); }, [refresh]);
 
+  const filtered = names.filter(n =>
+    n.toLowerCase().includes(query.toLowerCase())
+  );
+
   return (
     <div className="workflow-list">
-      <div className="list-header">
+      <div className="list-header page-header">
         <h2>Workflows</h2>
         <button
           className="create-btn"
@@ -50,8 +55,14 @@ export default function WorkflowList({
           </svg>
         </button>
       </div>
+      <input
+        className="workflow-search"
+        placeholder="Search workflows"
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+      />
       <ul>
-        {names.map((name) => (
+        {filtered.map((name) => (
           <li
             key={name}
             className="workflow-item"

--- a/src/components/WorkflowList.tsx
+++ b/src/components/WorkflowList.tsx
@@ -28,6 +28,14 @@ export default function WorkflowList({
     <div className="workflow-list">
       <div className="list-header page-header">
         <h2>Workflows</h2>
+      </div>
+      <div className="workflow-controls">
+        <input
+          className="workflow-search"
+          placeholder="Search workflows"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
         <button
           className="create-btn"
           title="New Workflow"
@@ -55,12 +63,6 @@ export default function WorkflowList({
           </svg>
         </button>
       </div>
-      <input
-        className="workflow-search"
-        placeholder="Search workflows"
-        value={query}
-        onChange={e => setQuery(e.target.value)}
-      />
       <ul>
         {filtered.map((name) => (
           <li

--- a/src/components/WorkflowList.tsx
+++ b/src/components/WorkflowList.tsx
@@ -30,12 +30,33 @@ export default function WorkflowList({
         <h2>Workflows</h2>
       </div>
       <div className="workflow-controls">
-        <input
-          className="workflow-search"
-          placeholder="Search workflows"
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-        />
+        <div className="search-wrap">
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <circle
+              cx="11"
+              cy="11"
+              r="7"
+              stroke="currentColor"
+              strokeWidth="2"
+              fill="none"
+            />
+            <line
+              x1="16"
+              y1="16"
+              x2="22"
+              y2="22"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+          <input
+            className="workflow-search"
+            placeholder="Search workflows"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+        </div>
         <button
           className="create-btn"
           title="New Workflow"

--- a/src/theme.css
+++ b/src/theme.css
@@ -455,10 +455,14 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  padding: 2px 6px;
+  height: 36px;
+  padding: 0 8px;
   border: 1px solid #6663;
   border-radius: 8px;
-  background: var(--bg);
+  background: #f7f7f7;
+}
+.dark .search-wrap {
+  background: #303134;
 }
 .search-wrap svg {
   flex: none;
@@ -470,6 +474,10 @@
   padding: 0;
   background: none;
   outline: none;
+  color: var(--fg);
+}
+.workflow-search::placeholder {
+  color: #888;
 }
 .workflow-item {
   display: flex;

--- a/src/theme.css
+++ b/src/theme.css
@@ -433,13 +433,17 @@
   font-size: 1.3rem;
   cursor: pointer;
 }
-.workflow-search {
+.workflow-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 0.75rem;
+}
+.workflow-search {
+  flex: 1;
   padding: 2px 4px;
   border: 1px solid #6663;
   border-radius: 8px;
-  width: 100%;
-  box-sizing: border-box;
 }
 .workflow-item {
   display: flex;

--- a/src/theme.css
+++ b/src/theme.css
@@ -372,6 +372,8 @@
   font-weight: bold;
   text-align: center;
   margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid #6663;
 }
 .sidebar button {
   width: 100%;
@@ -405,11 +407,21 @@
   list-style: none;
   padding: 0;
 }
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid #6663;
+}
 .list-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid #6663;
 }
 .create-btn {
   background: var(--accent);
@@ -420,6 +432,14 @@
   height: 36px;
   font-size: 1.3rem;
   cursor: pointer;
+}
+.workflow-search {
+  margin-bottom: 0.75rem;
+  padding: 2px 4px;
+  border: 1px solid #6663;
+  border-radius: 8px;
+  width: 100%;
+  box-sizing: border-box;
 }
 .workflow-item {
   display: flex;

--- a/src/theme.css
+++ b/src/theme.css
@@ -444,8 +444,6 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 0.75rem;
-  padding-bottom: 0.25rem;
-  border-bottom: 1px solid #6663;
 }
 .create-label {
   font-size: 0.9rem;

--- a/src/theme.css
+++ b/src/theme.css
@@ -428,16 +428,25 @@
   color: #fff;
   border: none;
   border-radius: 4px;
-  width: 36px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   height: 36px;
+  padding: 0 10px;
   font-size: 1.3rem;
   cursor: pointer;
+}
+.create-btn svg {
+  flex: none;
 }
 .workflow-controls {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 0.75rem;
+}
+.create-label {
+  font-size: 0.9rem;
 }
 .workflow-search {
   flex: 1;

--- a/src/theme.css
+++ b/src/theme.css
@@ -444,15 +444,32 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 0.75rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid #6663;
 }
 .create-label {
   font-size: 0.9rem;
 }
-.workflow-search {
+.search-wrap {
   flex: 1;
-  padding: 2px 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
   border: 1px solid #6663;
   border-radius: 8px;
+  background: var(--bg);
+}
+.search-wrap svg {
+  flex: none;
+  color: #666;
+}
+.workflow-search {
+  flex: 1;
+  border: none;
+  padding: 0;
+  background: none;
+  outline: none;
 }
 .workflow-item {
   display: flex;


### PR DESCRIPTION
## Summary
- add borders to sidebar logo and page headers
- style workflow search box
- wrap settings/tools titles in page header container
- include search input in workflow list

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_6847be3a2404832787a8b95d2f5526ba