### PR TITLE
Add editor page header

### DIFF
--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -24,12 +24,44 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
   return (
     <>
       <div className="page-header editor-header">
-        <button className="back" onClick={onBack}>Back</button>
-        <h2>
+        <button className="back-btn" onClick={onBack} aria-label="Back">
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <polyline
+              points="15 18 9 12 15 6"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+        <h2 className="editor-title">
           {name}
           {dirty && <span className="unsaved">*</span>}
+          <button
+            className="name-edit-btn"
+            title="Rename"
+            onClick={startEdit}
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M12 20h9"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+              <path
+                d="M16.5 3.5l4 4L7 21H3v-4L16.5 3.5z"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
         </h2>
-        <button className="edit" onClick={startEdit}>Edit</button>
       </div>
       {editing && (
         <>

--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { useWorkflowStore } from '../store/workflowStore';
+
+export default function EditorHeader({ onBack }: { onBack: () => void }) {
+  const name = useWorkflowStore(s => s.workflowName);
+  const dirty = useWorkflowStore(s => s.dirty);
+  const rename = useWorkflowStore(s => s.renameWorkflow);
+
+  const [editing, setEditing] = useState(false);
+  const [newName, setNewName] = useState(name);
+
+  const startEdit = () => {
+    setNewName(name);
+    setEditing(true);
+  };
+
+  const save = () => {
+    if (newName && newName !== name) {
+      rename(name, newName);
+    }
+    setEditing(false);
+  };
+
+  return (
+    <>
+      <div className="page-header editor-header">
+        <button className="back" onClick={onBack}>Back</button>
+        <h2>
+          {name}
+          {dirty && <span className="unsaved">*</span>}
+        </h2>
+        <button className="edit" onClick={startEdit}>Edit</button>
+      </div>
+      {editing && (
+        <>
+          <div className="modal-backdrop" onClick={() => setEditing(false)} />
+          <div className="modal" onClick={e => e.stopPropagation()}>
+            <h3>Rename Workflow</h3>
+            <input value={newName} onChange={e => setNewName(e.target.value)} />
+            <div className="modal-buttons">
+              <button onClick={() => setEditing(false)}>Cancel</button>
+              <button onClick={save}>Save</button>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/EditorPage.tsx
+++ b/src/components/EditorPage.tsx
@@ -6,12 +6,14 @@ import EditorHeader from './EditorHeader';
 
 export default function EditorPage({ onBack }: { onBack: () => void }) {
   return (
-    <div className="main editor-main">
+    <main className="main editor-page">
       <EditorHeader onBack={onBack} />
-      <WorkflowManager />
-      <NodePalette />
-      <EditorCanvas />
-      <PropertiesPanel />
-    </div>
+      <div className="editor-main">
+        <WorkflowManager />
+        <NodePalette />
+        <EditorCanvas />
+        <PropertiesPanel />
+      </div>
+    </main>
   );
 }

--- a/src/components/EditorPage.tsx
+++ b/src/components/EditorPage.tsx
@@ -2,11 +2,13 @@ import NodePalette from './NodePalette';
 import EditorCanvas from './EditorCanvas';
 import PropertiesPanel from './PropertiesPanel';
 import WorkflowManager from './WorkflowManager';
+import EditorHeader from './EditorHeader';
 
 export default function EditorPage({ onBack }: { onBack: () => void }) {
   return (
     <div className="main editor-main">
-      <WorkflowManager onBack={onBack} />
+      <EditorHeader onBack={onBack} />
+      <WorkflowManager />
       <NodePalette />
       <EditorCanvas />
       <PropertiesPanel />

--- a/src/components/WorkflowManager.tsx
+++ b/src/components/WorkflowManager.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 
-export default function WorkflowManager({ onBack }: { onBack: () => void }) {
+export default function WorkflowManager() {
   const save = useWorkflowStore((s) => s.saveWorkflow);
   const current = useWorkflowStore((s) => s.workflowName);
   const dirty = useWorkflowStore((s) => s.dirty);
@@ -21,12 +21,5 @@ export default function WorkflowManager({ onBack }: { onBack: () => void }) {
 
   /* Save actions are handled automatically via auto-save */
 
-  return (
-    <>
-      <div className="workflow-bar">
-        <button className="back" onClick={onBack}>Back</button>
-        {dirty && <span className="unsaved">*</span>}
-      </div>
-    </>
-  );
+  return null;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -415,6 +415,19 @@
   padding-bottom: 0.25rem;
   border-bottom: 1px solid #6663;
 }
+.editor-header h2 {
+  margin: 0;
+  flex: 1;
+  text-align: center;
+}
+.editor-header button {
+  background: none;
+  color: var(--fg);
+  border: 1px solid #6663;
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
 .list-header {
   display: flex;
   align-items: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -421,6 +421,10 @@
   padding-bottom: 0.25rem;
   border-bottom: 1px solid #6663;
 }
+.editor-header {
+  position: relative;
+  justify-content: center;
+}
 .editor-header button {
   background: none;
   color: var(--fg);
@@ -432,9 +436,16 @@
   align-items: center;
   justify-content: center;
 }
+.editor-header .back-btn {
+  position: absolute;
+  left: 1rem;
+}
+.editor-header .name-edit-btn {
+  display: inline-flex;
+  align-items: center;
+}
 .editor-header .editor-title {
   margin: 0;
-  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -421,11 +421,6 @@
   padding-bottom: 0.25rem;
   border-bottom: 1px solid #6663;
 }
-.editor-header h2 {
-  margin: 0;
-  flex: 1;
-  text-align: center;
-}
 .editor-header button {
   background: none;
   color: var(--fg);
@@ -433,6 +428,17 @@
   border-radius: 4px;
   padding: 2px 6px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.editor-header .editor-title {
+  margin: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
 }
 .list-header {
   display: flex;

--- a/src/theme.css
+++ b/src/theme.css
@@ -439,10 +439,15 @@
 .editor-header .back-btn {
   position: absolute;
   left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
 }
 .editor-header .name-edit-btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  margin-left: 0.25rem;
 }
 .editor-header .editor-title {
   margin: 0;

--- a/src/theme.css
+++ b/src/theme.css
@@ -398,6 +398,12 @@
   flex: 1;
   padding: 0.5rem;
 }
+.editor-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 0;
+}
 .editor-main {
   display: flex;
   height: 100%;


### PR DESCRIPTION
## Summary
- create `EditorHeader` component for editor view
- integrate new header in `EditorPage`
- move autosave logic into `WorkflowManager` only
- style editor header in `theme.css`

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_6847c5821128832794db2084aff60f1c