### PR TITLE
Add Assistants and Chat pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import WorkflowList from './components/WorkflowList';
 import EditorPage from './components/EditorPage';
 import SettingsPage from './components/SettingsPage';
 import ToolsPage from './components/ToolsPage';
+import AssistantsPage from './components/AssistantsPage';
+import ChatPage from './components/ChatPage';
 import clsx from 'clsx';
 
 export default function App() {
@@ -14,9 +16,9 @@ export default function App() {
   const loadWorkflow = useWorkflowStore((s) => s.loadWorkflow);
   const createWorkflow = useWorkflowStore((s) => s.createWorkflow);
 
-  const [page, setPage] = useState<'workflows' | 'editor' | 'settings' | 'tools'>(
-    'workflows'
-  );
+  const [page, setPage] = useState<
+    'workflows' | 'editor' | 'settings' | 'tools' | 'assistants' | 'chat'
+  >('workflows');
 
   useEffect(() => {
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
@@ -39,7 +41,12 @@ export default function App() {
     <div className={clsx('app-container', theme)}>
       {page !== 'editor' && (
         <Sidebar
-          current={page as 'workflows' | 'settings' | 'tools'}
+          current={page as
+            | 'workflows'
+            | 'settings'
+            | 'tools'
+            | 'assistants'
+            | 'chat'}
           onNavigate={setPage}
         />
       )}
@@ -49,6 +56,9 @@ export default function App() {
           <WorkflowList onOpen={openWorkflow} onCreate={createAndOpen} />
         </main>
       )}
+
+      {page === 'assistants' && <AssistantsPage />}
+      {page === 'chat' && <ChatPage />}
 
       {page === 'settings' && <SettingsPage />}
       {page === 'tools' && <ToolsPage />}

--- a/src/components/AssistantsPage.tsx
+++ b/src/components/AssistantsPage.tsx
@@ -1,0 +1,9 @@
+export default function AssistantsPage() {
+  return (
+    <main className="main">
+      <div className="page-header">
+        <h2>Assistants</h2>
+      </div>
+    </main>
+  );
+}

--- a/src/components/ChatPage.tsx
+++ b/src/components/ChatPage.tsx
@@ -1,0 +1,9 @@
+export default function ChatPage() {
+  return (
+    <main className="main">
+      <div className="page-header">
+        <h2>Chat</h2>
+      </div>
+    </main>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,8 +1,10 @@
 import clsx from 'clsx';
 
 export default function Sidebar({ current, onNavigate }: {
-  current: 'workflows' | 'settings' | 'tools';
-  onNavigate: (page: 'workflows' | 'settings' | 'tools') => void;
+  current: 'workflows' | 'settings' | 'tools' | 'assistants' | 'chat';
+  onNavigate: (
+    page: 'workflows' | 'settings' | 'tools' | 'assistants' | 'chat'
+  ) => void;
 }) {
   return (
     <nav className="sidebar">
@@ -11,7 +13,19 @@ export default function Sidebar({ current, onNavigate }: {
         className={clsx({ active: current === 'workflows' })}
         onClick={() => onNavigate('workflows')}
       >
-        Workflows
+        Agents
+      </button>
+      <button
+        className={clsx({ active: current === 'assistants' })}
+        onClick={() => onNavigate('assistants')}
+      >
+        Assistants
+      </button>
+      <button
+        className={clsx({ active: current === 'chat' })}
+        onClick={() => onNavigate('chat')}
+      >
+        Chat
       </button>
       <button
         className={clsx({ active: current === 'tools' })}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,28 +10,28 @@ export default function Sidebar({ current, onNavigate }: {
     <nav className="sidebar">
       <div className="logo">Logo</div>
       <button
-        className={clsx({ active: current === 'workflows' })}
-        onClick={() => onNavigate('workflows')}
-      >
-        Agents
-      </button>
-      <button
-        className={clsx({ active: current === 'assistants' })}
-        onClick={() => onNavigate('assistants')}
-      >
-        Assistants
-      </button>
-      <button
         className={clsx({ active: current === 'chat' })}
         onClick={() => onNavigate('chat')}
       >
         Chat
       </button>
       <button
+        className={clsx({ active: current === 'workflows' })}
+        onClick={() => onNavigate('workflows')}
+      >
+        Agents
+      </button>
+      <button
         className={clsx({ active: current === 'tools' })}
         onClick={() => onNavigate('tools')}
       >
         Tools
+      </button>
+      <button
+        className={clsx({ active: current === 'assistants' })}
+        onClick={() => onNavigate('assistants')}
+      >
+        Assistants
       </button>
       <button
         className={clsx({ active: current === 'settings' })}

--- a/src/components/WorkflowList.tsx
+++ b/src/components/WorkflowList.tsx
@@ -27,7 +27,7 @@ export default function WorkflowList({
   return (
     <div className="workflow-list">
       <div className="list-header page-header">
-        <h2>Workflows</h2>
+        <h2>Agents</h2>
       </div>
       <div className="workflow-controls">
         <div className="search-wrap">


### PR DESCRIPTION
## Summary
- rename sidebar 'Workflows' button to **Agents**
- add Assistants and Chat page components
- hook new pages up in `App` and navigation

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_6847cb6f751883278b7218925001f212