### PR TITLE
Implement tools management page

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -146,6 +146,19 @@
       "fields": []
     },
     {
+      "id": "tool.start",
+      "name": "Tool Start",
+      "tags": ["tool", "start"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [],
+      "fields": [
+        { "id": "name", "label": "Name", "type": "string" },
+        { "id": "description", "label": "Description", "type": "string" },
+        { "id": "schema", "label": "JSON Schema", "type": "string" }
+      ]
+    },
+    {
       "id": "agent",
       "name": "Agent",
       "tags": ["agent"],

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -159,6 +159,24 @@
       ]
     },
     {
+      "id": "tool.end",
+      "name": "Tool End",
+      "tags": ["tool", "end"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "stateIn",
+          "name": "State",
+          "direction": "input",
+          "type": "State",
+          "cardinality": "many",
+          "required": true
+        }
+      ],
+      "outputs": [],
+      "fields": []
+    },
+    {
       "id": "agent",
       "name": "Agent",
       "tags": ["agent"],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,13 @@ export default function App() {
   const theme = useWorkflowStore((s) => s.theme);
   const loadDefs = useWorkflowStore((s) => s.loadDefinitions);
   const loadWorkflow = useWorkflowStore((s) => s.loadWorkflow);
+  const loadTool = useWorkflowStore((s) => s.loadTool);
   const createWorkflow = useWorkflowStore((s) => s.createWorkflow);
 
   const [page, setPage] = useState<
     'workflows' | 'editor' | 'settings' | 'tools' | 'assistants' | 'chat'
   >('workflows');
+  const [returnPage, setReturnPage] = useState<'workflows' | 'tools'>('workflows');
 
   useEffect(() => {
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
@@ -29,11 +31,19 @@ export default function App() {
 
   const openWorkflow = (name: string) => {
     loadWorkflow(name);
+    setReturnPage('workflows');
+    setPage('editor');
+  };
+
+  const openTool = (name: string) => {
+    loadTool(name);
+    setReturnPage('tools');
     setPage('editor');
   };
 
   const createAndOpen = () => {
     createWorkflow();
+    setReturnPage('workflows');
     setPage('editor');
   };
 
@@ -61,10 +71,10 @@ export default function App() {
       {page === 'chat' && <ChatPage />}
 
       {page === 'settings' && <SettingsPage />}
-      {page === 'tools' && <ToolsPage />}
+      {page === 'tools' && <ToolsPage onOpen={openTool} />}
 
       {page === 'editor' && (
-        <EditorPage onBack={() => setPage('workflows')} />
+        <EditorPage onBack={() => setPage(returnPage)} />
       )}
 
       <ErrorToast />

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -13,7 +13,7 @@ interface ToolData {
   edges: EdgeInstance[];
 }
 
-export default function ToolsPage() {
+export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }) {
   const [tools, setTools] = useState<string[]>([]);
   const [query, setQuery] = useState('');
 
@@ -153,7 +153,11 @@ export default function ToolsPage() {
       </div>
       <ul>
         {filtered.map(name => (
-          <li key={name} className="workflow-item">
+          <li
+            key={name}
+            className="workflow-item"
+            onClick={() => onOpen(name)}
+          >
             <span className="workflow-name">{name}</span>
             <div className="item-actions" onClick={e => e.stopPropagation()}>
               <button title="Edit" onClick={() => openEdit(name)}>✏️</button>

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -45,11 +45,26 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
       parsed = { nodes: {}, edges: [] };
     }
 
-    let start = Object.values(parsed.nodes).find(n => n.nodeTypeId === 'tool.start');
+    let start = Object.values(parsed.nodes).find((n) => n.nodeTypeId === 'tool.start');
     if (!start) {
       const id = uuid();
-      start = { uuid: id, nodeTypeId: 'tool.start', position: { x: 0, y: 0 }, fields: {} };
+      start = {
+        uuid: id,
+        nodeTypeId: 'tool.start',
+        position: { x: 0, y: 0 },
+        fields: {},
+      };
       parsed.nodes[id] = start;
+    }
+
+    if (!Object.values(parsed.nodes).some((n) => n.nodeTypeId === 'tool.end')) {
+      const id = uuid();
+      parsed.nodes[id] = {
+        uuid: id,
+        nodeTypeId: 'tool.end',
+        position: { x: 200, y: 0 },
+        fields: {},
+      };
     }
 
     setMetaName((start.fields as any).name || name);
@@ -68,14 +83,24 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
       name = `${base} ${++idx}`;
     }
 
-    const id = uuid();
+    const startId = uuid();
+    const endId = uuid();
     const start: NodeInstance = {
-      uuid: id,
+      uuid: startId,
       nodeTypeId: 'tool.start',
       position: { x: 0, y: 0 },
-      fields: { name: '', description: '', schema: '' }
+      fields: { name: '', description: '', schema: '' },
     };
-    const newData: ToolData = { nodes: { [id]: start }, edges: [] };
+    const end: NodeInstance = {
+      uuid: endId,
+      nodeTypeId: 'tool.end',
+      position: { x: 200, y: 0 },
+      fields: {},
+    };
+    const newData: ToolData = {
+      nodes: { [startId]: start, [endId]: end },
+      edges: [],
+    };
     localStorage.setItem(`tool.${name}`, JSON.stringify(newData));
     list.push(name);
     localStorage.setItem('tools', JSON.stringify(list));

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -1,9 +1,194 @@
+import { useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import type { NodeInstance, EdgeInstance } from '../types';
+
+interface ToolMeta {
+  name: string;
+  description: string;
+  schema: string;
+}
+
+interface ToolData {
+  nodes: Record<string, NodeInstance>;
+  edges: EdgeInstance[];
+}
+
 export default function ToolsPage() {
+  const [tools, setTools] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
+
+  const [editing, setEditing] = useState<string | null>(null);
+  const [metaName, setMetaName] = useState('');
+  const [metaDesc, setMetaDesc] = useState('');
+  const [metaSchema, setMetaSchema] = useState('');
+  const [data, setData] = useState<ToolData | null>(null);
+
+  const refresh = () => {
+    const list = localStorage.getItem('tools');
+    setTools(list ? JSON.parse(list) : []);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const openEdit = (name: string) => {
+    const raw = localStorage.getItem(`tool.${name}`);
+    let parsed: ToolData;
+    if (raw) {
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        parsed = { nodes: {}, edges: [] };
+      }
+    } else {
+      parsed = { nodes: {}, edges: [] };
+    }
+
+    let start = Object.values(parsed.nodes).find(n => n.nodeTypeId === 'tool.start');
+    if (!start) {
+      const id = uuid();
+      start = { uuid: id, nodeTypeId: 'tool.start', position: { x: 0, y: 0 }, fields: {} };
+      parsed.nodes[id] = start;
+    }
+
+    setMetaName((start.fields as any).name || name);
+    setMetaDesc((start.fields as any).description || '');
+    setMetaSchema((start.fields as any).schema || '');
+    setEditing(name);
+    setData(parsed);
+  };
+
+  const createTool = () => {
+    const list = tools.slice();
+    let base = 'Untitled Tool';
+    let idx = 1;
+    let name = `${base} ${idx}`;
+    while (list.includes(name)) {
+      name = `${base} ${++idx}`;
+    }
+
+    const id = uuid();
+    const start: NodeInstance = {
+      uuid: id,
+      nodeTypeId: 'tool.start',
+      position: { x: 0, y: 0 },
+      fields: { name: '', description: '', schema: '' }
+    };
+    const newData: ToolData = { nodes: { [id]: start }, edges: [] };
+    localStorage.setItem(`tool.${name}`, JSON.stringify(newData));
+    list.push(name);
+    localStorage.setItem('tools', JSON.stringify(list));
+    setTools(list);
+    openEdit(name);
+  };
+
+  const saveTool = () => {
+    if (!editing || !data) return;
+    const list = localStorage.getItem('tools');
+    const names: string[] = list ? JSON.parse(list) : [];
+
+    const start = Object.values(data.nodes).find(n => n.nodeTypeId === 'tool.start');
+    if (start) {
+      (start.fields as any).name = metaName;
+      (start.fields as any).description = metaDesc;
+      (start.fields as any).schema = metaSchema;
+    }
+
+    let target = editing;
+    if (metaName && metaName !== editing) {
+      if (names.includes(metaName)) {
+        alert('Name already exists');
+        return;
+      }
+      target = metaName;
+      const idx = names.indexOf(editing);
+      if (idx !== -1) names[idx] = metaName;
+      localStorage.removeItem(`tool.${editing}`);
+    }
+    localStorage.setItem('tools', JSON.stringify(names));
+    localStorage.setItem(`tool.${target}`, JSON.stringify(data));
+    setEditing(null);
+    setData(null);
+    refresh();
+  };
+
+  const deleteTool = (name: string) => {
+    const list = localStorage.getItem('tools');
+    const names: string[] = list ? JSON.parse(list) : [];
+    const idx = names.indexOf(name);
+    if (idx !== -1) names.splice(idx, 1);
+    localStorage.setItem('tools', JSON.stringify(names));
+    localStorage.removeItem(`tool.${name}`);
+    setTools(names);
+  };
+
+  const filtered = tools.filter(t => t.toLowerCase().includes(query.toLowerCase()));
+
   return (
     <main className="main">
       <div className="page-header">
         <h2>Tools</h2>
       </div>
+      <div className="workflow-controls">
+        <div className="search-wrap">
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" fill="none" />
+            <line x1="16" y1="16" x2="22" y2="22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <input
+            className="workflow-search"
+            placeholder="Search..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+        </div>
+        <button className="create-btn" title="New Tool" onClick={createTool}>
+          <svg width="16" height="16" viewBox="0 0 12 12" aria-hidden="true">
+            <line x1="1" y1="6" x2="11" y2="6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            <line x1="6" y1="1" x2="6" y2="11" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <span className="create-label">New</span>
+        </button>
+      </div>
+      <ul>
+        {filtered.map(name => (
+          <li key={name} className="workflow-item">
+            <span className="workflow-name">{name}</span>
+            <div className="item-actions" onClick={e => e.stopPropagation()}>
+              <button title="Edit" onClick={() => openEdit(name)}>✏️</button>
+              <button className="delete" title="Delete" onClick={() => deleteTool(name)}>
+                🗑️
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {editing && (
+        <>
+          <div className="modal-backdrop" onClick={() => setEditing(null)} />
+          <div className="modal" onClick={e => e.stopPropagation()}>
+            <h3>Edit Tool</h3>
+            <label className="field-label">
+              Name
+              <input type="text" value={metaName} onChange={e => setMetaName(e.target.value)} />
+            </label>
+            <label className="field-label">
+              Description
+              <input type="text" value={metaDesc} onChange={e => setMetaDesc(e.target.value)} />
+            </label>
+            <label className="field-label">
+              JSON Schema
+              <input type="text" value={metaSchema} onChange={e => setMetaSchema(e.target.value)} />
+            </label>
+            <div className="modal-buttons">
+              <button onClick={() => setEditing(null)}>Cancel</button>
+              <button onClick={saveTool}>Save</button>
+            </div>
+          </div>
+        </>
+      )}
     </main>
   );
 }

--- a/src/components/WorkflowManager.tsx
+++ b/src/components/WorkflowManager.tsx
@@ -2,7 +2,8 @@ import { useEffect } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 
 export default function WorkflowManager() {
-  const save = useWorkflowStore((s) => s.saveWorkflow);
+  const saveWorkflow = useWorkflowStore((s) => s.saveWorkflow);
+  const saveTool = useWorkflowStore((s) => s.saveTool);
   const current = useWorkflowStore((s) => s.workflowName);
   const dirty = useWorkflowStore((s) => s.dirty);
   const nodes = useWorkflowStore((s) => s.nodes);
@@ -12,12 +13,16 @@ export default function WorkflowManager() {
   useEffect(() => {
     if (current && dirty) {
       try {
-        save(current);
+        if (current.startsWith('tool:')) {
+          saveTool(current.slice(5));
+        } else {
+          saveWorkflow(current);
+        }
       } catch {
         setToast('Auto-save failed');
       }
     }
-  }, [nodes, edges, current, dirty, save, setToast]);
+  }, [nodes, edges, current, dirty, saveWorkflow, saveTool, setToast]);
 
   /* Save actions are handled automatically via auto-save */
 


### PR DESCRIPTION
## Summary
- list local custom tool definitions
- allow creating, editing, and deleting tools
- store metadata on `tool.start` node

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_68483e38ed2083279e4d1d2cb891c035