### PR TITLE
Add object field type support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@ This project implements a visual node editor for building AI workflows. The arch
 ├─ public/            # Static assets served as-is
 │   └─ nodeTypes.json # Node type definitions (see below)
 ├─ src/               # React + TypeScript source
-│   ├─ components/    # UI components
-│   ├─ store/         # Zustand state store
-│   ├─ logic/         # Business logic helpers
+│   ├─ components/    # UI components (canvas, palette, workflow manager, etc.)
+│   ├─ store/         # Zustand state store with localStorage persistence
+│   ├─ logic/         # Business logic helpers & validation
+│   │   └─ __tests__/ # Vitest unit tests
 │   ├─ index.css      # Base styles
 │   ├─ theme.css      # Light/Dark themes via CSS variables
 │   └─ types.ts       # Shared TypeScript interfaces
@@ -21,15 +22,16 @@ This project implements a visual node editor for building AI workflows. The arch
 ```
 
 ### Key Components
-- **App.tsx** – Root component that fetches node definitions and renders the palette, canvas, properties panel and error toast.
+- **App.tsx** – Root component that fetches node definitions and renders the workflow manager, palette, canvas, properties panel and error toast.
 - **components/**
-  - `NodePalette.tsx` – Sidebar listing available node types with search; provides drag-and-drop to add nodes.
+  - `WorkflowManager.tsx` – Dropdown + modals to save/load/delete workflows (autosave).
+  - `NodePalette.tsx` – Sidebar of node types with search, drag-and-drop and a validate button.
   - `EditorCanvas.tsx` – Wraps the React Flow canvas and synchronises with the store.
-  - `CustomNode.tsx` – Renders nodes using the single-row layout from the design doc.
-  - `PropertiesPanel.tsx` – Edits the selected node's fields.
+  - `CustomNode.tsx` – Renders nodes using the single-row layout and exposes an edit button.
+  - `PropertiesPanel.tsx` – Modal editor for the selected node's fields.
   - `ErrorToast.tsx` – Transient error display.
-- **store/workflowStore.ts** – Zustand store implementing the workflow state model from the design doc.
-- **logic/pinValidation.ts** – Placeholder for connection validation (future work).
+- **store/workflowStore.ts** – Zustand store implementing the workflow state model and localStorage persistence.
+- **logic/pinValidation.ts** – Implements connection and workflow validation (tested).
 
 ### Node Definitions
 Node types are **entirely described in `public/nodeTypes.json`**. The editor does not hard-code names, pins or fields; every attribute comes from this JSON file:
@@ -40,17 +42,21 @@ Node types are **entirely described in `public/nodeTypes.json`**. The editor doe
 
 Adding or modifying a node only requires editing this JSON—no code changes are needed. The store loads the file at startup and the rest of the UI references these definitions.
 
+Recent updates added additional node types (start/end nodes, embeddings and extra tools).
+
 ### Architecture Overview
 - **React 18 + TypeScript** – UI framework
 - **@xyflow/react** – Canvas / edges rendering
 - **Zustand** – Centralised state management with `immer` middleware
 - **Vite** – Build tool and dev server
 - **UUID** – `uuid` package used for deterministic IDs
+- **Vitest** – Unit test runner
 
 The high-level component map mirrors `DesignDoc.md`:
 
 ```
 App
+├─ WorkflowManager
 ├─ NodePalette
 ├─ EditorCanvas
 │   └─ CustomNode (via ReactFlow)
@@ -60,12 +66,14 @@ App
 ### Data Flow
 1. `App.tsx` loads `nodeTypes.json` and populates the store with `NodeType` objects and the type hierarchy.
 2. Dragging from the palette spawns nodes on the canvas with new UUIDs.
-3. Connections are created via React Flow; validation will reside in `logic/pinValidation.ts`.
+3. Connections are created via React Flow and validated by `logic/pinValidation.ts`.
 4. Selecting a node opens its fields in `PropertiesPanel` for editing.
-5. Theme preference is persisted in `localStorage`.
+5. Workflows auto-save to `localStorage`; `WorkflowManager` lets users save, load and delete named flows.
+6. Theme preference is persisted in `localStorage`.
 
 ### Notes for Contributors
 - Follow the design intent in `DesignDoc.md` when adding features or refactoring.
 - Run `npm run verify` before committing changes to compile, type-check and run the tests.
 - The repo currently uses plain CSS; switch to CSS Modules or Tailwind only if consistent with the design doc.
 - If the project structure or workflow changes, **update this `AGENTS.md`** to keep it current.
+- When submitting a PR with significant changes, add, modify or remove sections of this file so it accurately reflects the new state of the project.

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -156,7 +156,7 @@
       "fields": [
         { "id": "name", "label": "Name", "type": "string" },
         { "id": "description", "label": "Description", "type": "string" },
-        { "id": "schema", "label": "JSON Schema", "type": "string" }
+        { "id": "schema", "label": "JSON Schema", "type": "object" }
       ]
     },
     {

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -5,6 +5,7 @@
     "Tool": null,
     "State": null,
     "Text": null,
+    "Json": null,
     "Embeddings": null,
     "OpenAIEmbeddings": "Embeddings",
     "WebSearch": "Tool",
@@ -146,6 +147,37 @@
       "fields": []
     },
     {
+      "id": "tool.start",
+      "name": "Tool Start",
+      "tags": ["tool", "start"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [],
+      "fields": [
+        { "id": "name", "label": "Name", "type": "string" },
+        { "id": "description", "label": "Description", "type": "string" },
+        { "id": "schema", "label": "JSON Schema", "type": "string" }
+      ]
+    },
+    {
+      "id": "tool.end",
+      "name": "Tool End",
+      "tags": ["tool", "end"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "stateIn",
+          "name": "State",
+          "direction": "input",
+          "type": "State",
+          "cardinality": "many",
+          "required": true
+        }
+      ],
+      "outputs": [],
+      "fields": []
+    },
+    {
       "id": "agent",
       "name": "Agent",
       "tags": ["agent"],
@@ -247,6 +279,49 @@
           "name": "Tool",
           "direction": "output",
           "type": "MCP",
+          "cardinality": "many"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "tool.in",
+      "name": "Tool Input",
+      "tags": ["tool", "json", "input"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "jsonOut",
+          "name": "JSON",
+          "direction": "output",
+          "type": "Json",
+          "cardinality": "many"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "tool.out",
+      "name": "Tool Output",
+      "tags": ["tool", "json", "output"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "jsonIn",
+          "name": "JSON",
+          "direction": "input",
+          "type": "Json",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "Tool",
           "cardinality": "many"
         }
       ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,13 @@ export default function App() {
   const theme = useWorkflowStore((s) => s.theme);
   const loadDefs = useWorkflowStore((s) => s.loadDefinitions);
   const loadWorkflow = useWorkflowStore((s) => s.loadWorkflow);
+  const loadTool = useWorkflowStore((s) => s.loadTool);
   const createWorkflow = useWorkflowStore((s) => s.createWorkflow);
 
   const [page, setPage] = useState<
     'workflows' | 'editor' | 'settings' | 'tools' | 'assistants' | 'chat'
   >('workflows');
+  const [returnPage, setReturnPage] = useState<'workflows' | 'tools'>('workflows');
 
   useEffect(() => {
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
@@ -29,11 +31,19 @@ export default function App() {
 
   const openWorkflow = (name: string) => {
     loadWorkflow(name);
+    setReturnPage('workflows');
+    setPage('editor');
+  };
+
+  const openTool = (name: string) => {
+    loadTool(name);
+    setReturnPage('tools');
     setPage('editor');
   };
 
   const createAndOpen = () => {
     createWorkflow();
+    setReturnPage('workflows');
     setPage('editor');
   };
 
@@ -61,10 +71,10 @@ export default function App() {
       {page === 'chat' && <ChatPage />}
 
       {page === 'settings' && <SettingsPage />}
-      {page === 'tools' && <ToolsPage />}
+      {page === 'tools' && <ToolsPage onOpen={openTool} />}
 
       {page === 'editor' && (
-        <EditorPage onBack={() => setPage('workflows')} />
+        <EditorPage onBack={() => setPage(returnPage)} />
       )}
 
       <ErrorToast />

--- a/src/components/PropertiesPanel.tsx
+++ b/src/components/PropertiesPanel.tsx
@@ -32,12 +32,26 @@ export default function PropertiesPanel() {
 
 function FieldInput({ field, node }: { field: Field; node: NodeInstance }) {
   const update = useWorkflowStore((s) => s.updateNodeField);
-  const initial = node.fields[field.id] ?? field.default ?? '';
+  const initial = node.fields[field.id] ?? field.default ?? (field.type === 'object' ? {} : '');
   const [value, setValue] = useState<any>(initial);
+  const [text, setText] = useState(
+    field.type === 'object' ? JSON.stringify(initial, null, 2) : ''
+  );
 
   const onChange = (val: unknown) => {
     setValue(val);
     update(node.uuid, field.id, val);
+  };
+
+  const onTextChange = (str: string) => {
+    setText(str);
+    try {
+      const parsed = JSON.parse(str);
+      setValue(parsed);
+      update(node.uuid, field.id, parsed);
+    } catch {
+      /* keep old value until JSON is valid */
+    }
   };
 
   let input: JSX.Element;
@@ -86,6 +100,14 @@ function FieldInput({ field, node }: { field: Field; node: NodeInstance }) {
             </option>
           ))}
         </select>
+      );
+      break;
+    case 'object':
+      input = (
+        <textarea
+          value={text}
+          onChange={(e) => onTextChange(e.target.value)}
+        />
       );
       break;
     default:

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -1,9 +1,223 @@
-export default function ToolsPage() {
+import { useEffect, useState } from 'react';
+import { v4 as uuid } from 'uuid';
+import type { NodeInstance, EdgeInstance } from '../types';
+
+interface ToolMeta {
+  name: string;
+  description: string;
+  schema: string;
+}
+
+interface ToolData {
+  nodes: Record<string, NodeInstance>;
+  edges: EdgeInstance[];
+}
+
+export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }) {
+  const [tools, setTools] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
+
+  const [editing, setEditing] = useState<string | null>(null);
+  const [metaName, setMetaName] = useState('');
+  const [metaDesc, setMetaDesc] = useState('');
+  const [metaSchema, setMetaSchema] = useState('');
+  const [data, setData] = useState<ToolData | null>(null);
+
+  const refresh = () => {
+    const list = localStorage.getItem('tools');
+    setTools(list ? JSON.parse(list) : []);
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const openEdit = (name: string) => {
+    const raw = localStorage.getItem(`tool.${name}`);
+    let parsed: ToolData;
+    if (raw) {
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        parsed = { nodes: {}, edges: [] };
+      }
+    } else {
+      parsed = { nodes: {}, edges: [] };
+    }
+
+    let start = Object.values(parsed.nodes).find((n) => n.nodeTypeId === 'tool.start');
+    if (!start) {
+      const id = uuid();
+      start = {
+        uuid: id,
+        nodeTypeId: 'tool.start',
+        position: { x: 0, y: 0 },
+        fields: {},
+      };
+      parsed.nodes[id] = start;
+    }
+
+    if (!Object.values(parsed.nodes).some((n) => n.nodeTypeId === 'tool.end')) {
+      const id = uuid();
+      parsed.nodes[id] = {
+        uuid: id,
+        nodeTypeId: 'tool.end',
+        position: { x: 200, y: 0 },
+        fields: {},
+      };
+    }
+
+    setMetaName((start.fields as any).name || name);
+    setMetaDesc((start.fields as any).description || '');
+    setMetaSchema((start.fields as any).schema || '');
+    setEditing(name);
+    setData(parsed);
+  };
+
+  const createTool = () => {
+    const list = tools.slice();
+    let base = 'Untitled Tool';
+    let idx = 1;
+    let name = `${base} ${idx}`;
+    while (list.includes(name)) {
+      name = `${base} ${++idx}`;
+    }
+
+    const startId = uuid();
+    const endId = uuid();
+    const start: NodeInstance = {
+      uuid: startId,
+      nodeTypeId: 'tool.start',
+      position: { x: 0, y: 0 },
+      fields: { name: '', description: '', schema: '' },
+    };
+    const end: NodeInstance = {
+      uuid: endId,
+      nodeTypeId: 'tool.end',
+      position: { x: 200, y: 0 },
+      fields: {},
+    };
+    const newData: ToolData = {
+      nodes: { [startId]: start, [endId]: end },
+      edges: [],
+    };
+    localStorage.setItem(`tool.${name}`, JSON.stringify(newData));
+    list.push(name);
+    localStorage.setItem('tools', JSON.stringify(list));
+    setTools(list);
+    openEdit(name);
+  };
+
+  const saveTool = () => {
+    if (!editing || !data) return;
+    const list = localStorage.getItem('tools');
+    const names: string[] = list ? JSON.parse(list) : [];
+
+    const start = Object.values(data.nodes).find(n => n.nodeTypeId === 'tool.start');
+    if (start) {
+      (start.fields as any).name = metaName;
+      (start.fields as any).description = metaDesc;
+      (start.fields as any).schema = metaSchema;
+    }
+
+    let target = editing;
+    if (metaName && metaName !== editing) {
+      if (names.includes(metaName)) {
+        alert('Name already exists');
+        return;
+      }
+      target = metaName;
+      const idx = names.indexOf(editing);
+      if (idx !== -1) names[idx] = metaName;
+      localStorage.removeItem(`tool.${editing}`);
+    }
+    localStorage.setItem('tools', JSON.stringify(names));
+    localStorage.setItem(`tool.${target}`, JSON.stringify(data));
+    setEditing(null);
+    setData(null);
+    refresh();
+  };
+
+  const deleteTool = (name: string) => {
+    const list = localStorage.getItem('tools');
+    const names: string[] = list ? JSON.parse(list) : [];
+    const idx = names.indexOf(name);
+    if (idx !== -1) names.splice(idx, 1);
+    localStorage.setItem('tools', JSON.stringify(names));
+    localStorage.removeItem(`tool.${name}`);
+    setTools(names);
+  };
+
+  const filtered = tools.filter(t => t.toLowerCase().includes(query.toLowerCase()));
+
   return (
     <main className="main">
       <div className="page-header">
         <h2>Tools</h2>
       </div>
+      <div className="workflow-controls">
+        <div className="search-wrap">
+          <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" fill="none" />
+            <line x1="16" y1="16" x2="22" y2="22" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <input
+            className="workflow-search"
+            placeholder="Search..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+        </div>
+        <button className="create-btn" title="New Tool" onClick={createTool}>
+          <svg width="16" height="16" viewBox="0 0 12 12" aria-hidden="true">
+            <line x1="1" y1="6" x2="11" y2="6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            <line x1="6" y1="1" x2="6" y2="11" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <span className="create-label">New</span>
+        </button>
+      </div>
+      <ul>
+        {filtered.map(name => (
+          <li
+            key={name}
+            className="workflow-item"
+            onClick={() => onOpen(name)}
+          >
+            <span className="workflow-name">{name}</span>
+            <div className="item-actions" onClick={e => e.stopPropagation()}>
+              <button title="Edit" onClick={() => openEdit(name)}>✏️</button>
+              <button className="delete" title="Delete" onClick={() => deleteTool(name)}>
+                🗑️
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {editing && (
+        <>
+          <div className="modal-backdrop" onClick={() => setEditing(null)} />
+          <div className="modal" onClick={e => e.stopPropagation()}>
+            <h3>Edit Tool</h3>
+            <label className="field-label">
+              Name
+              <input type="text" value={metaName} onChange={e => setMetaName(e.target.value)} />
+            </label>
+            <label className="field-label">
+              Description
+              <input type="text" value={metaDesc} onChange={e => setMetaDesc(e.target.value)} />
+            </label>
+            <label className="field-label">
+              JSON Schema
+              <input type="text" value={metaSchema} onChange={e => setMetaSchema(e.target.value)} />
+            </label>
+            <div className="modal-buttons">
+              <button onClick={() => setEditing(null)}>Cancel</button>
+              <button onClick={saveTool}>Save</button>
+            </div>
+          </div>
+        </>
+      )}
     </main>
   );
 }

--- a/src/components/WorkflowManager.tsx
+++ b/src/components/WorkflowManager.tsx
@@ -2,7 +2,8 @@ import { useEffect } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 
 export default function WorkflowManager() {
-  const save = useWorkflowStore((s) => s.saveWorkflow);
+  const saveWorkflow = useWorkflowStore((s) => s.saveWorkflow);
+  const saveTool = useWorkflowStore((s) => s.saveTool);
   const current = useWorkflowStore((s) => s.workflowName);
   const dirty = useWorkflowStore((s) => s.dirty);
   const nodes = useWorkflowStore((s) => s.nodes);
@@ -12,12 +13,16 @@ export default function WorkflowManager() {
   useEffect(() => {
     if (current && dirty) {
       try {
-        save(current);
+        if (current.startsWith('tool:')) {
+          saveTool(current.slice(5));
+        } else {
+          saveWorkflow(current);
+        }
       } catch {
         setToast('Auto-save failed');
       }
     }
-  }, [nodes, edges, current, dirty, save, setToast]);
+  }, [nodes, edges, current, dirty, saveWorkflow, saveTool, setToast]);
 
   /* Save actions are handled automatically via auto-save */
 

--- a/src/logic/__tests__/objectFields.test.ts
+++ b/src/logic/__tests__/objectFields.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { validateWorkflow } from '../pinValidation';
+import type { NodeInstance, EdgeInstance, NodeType } from '../../types';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// define a simple node type requiring an object field
+const objectNode: NodeType = {
+  id: 'object.node',
+  name: 'Object Node',
+  tags: [],
+  layout: 'singleRow',
+  inputs: [],
+  outputs: [],
+  fields: [
+    { id: 'config', name: 'Config', label: 'Config', type: 'object', required: true }
+  ]
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const json = readFileSync(join(__dirname, '../../../public/nodeTypes.json'), 'utf-8');
+const defs: { types: Record<string, string | null>; nodes: NodeType[] } = JSON.parse(json);
+const hierarchy = defs.types;
+const nodeTypes = [...defs.nodes, objectNode];
+
+function makeNode(fields: Record<string, unknown>, uuid = '1'): NodeInstance {
+  return { uuid, nodeTypeId: 'object.node', position: { x: 0, y: 0 }, fields };
+}
+
+describe('object field handling', () => {
+  it('fails validation when required object field is empty', () => {
+    const nodes: Record<string, NodeInstance> = {
+      start: { uuid: 's', nodeTypeId: 'workflow.start', position: { x: 0, y: 0 }, fields: {} },
+      end: { uuid: 'e', nodeTypeId: 'workflow.end', position: { x: 0, y: 0 }, fields: {} },
+      obj: makeNode({})
+    };
+    const edges: EdgeInstance[] = [];
+    const err = validateWorkflow(nodes, edges, nodeTypes, hierarchy);
+    expect(err).toMatch(/required/i);
+  });
+
+  it('serializes and deserializes object fields', () => {
+    const node = makeNode({ config: { a: 1, b: 'two' } });
+    const str = JSON.stringify(node);
+    const parsed = JSON.parse(str) as NodeInstance;
+    expect(parsed.fields).toEqual(node.fields);
+  });
+});

--- a/src/logic/__tests__/objectFields.test.ts
+++ b/src/logic/__tests__/objectFields.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { validateWorkflow } from '../pinValidation';
+import { parseSchema, buildSchema } from '../schemaUtils';
 import type { NodeInstance, EdgeInstance, NodeType } from '../../types';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -45,5 +46,23 @@ describe('object field handling', () => {
     const str = JSON.stringify(node);
     const parsed = JSON.parse(str) as NodeInstance;
     expect(parsed.fields).toEqual(node.fields);
+  });
+
+  it('parses and builds simple schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' },
+        bar: { type: 'number' },
+      },
+      required: ['bar'],
+    };
+    const entries = parseSchema(schema);
+    expect(entries).toEqual([
+      { name: 'foo', type: 'string', required: false },
+      { name: 'bar', type: 'number', required: true },
+    ]);
+    const rebuilt = buildSchema(entries);
+    expect(rebuilt).toEqual(schema);
   });
 });

--- a/src/logic/pinValidation.ts
+++ b/src/logic/pinValidation.ts
@@ -148,7 +148,12 @@ export function validateWorkflow(
     for (const field of def.fields) {
       if (field.required) {
         const val = node.fields[field.id] ?? field.default;
-        if (val === undefined || val === '') {
+        if (
+          val === undefined ||
+          val === '' ||
+          (field.type === 'object' &&
+            (typeof val !== 'object' || val === null || Object.keys(val).length === 0))
+        ) {
           return `Field ${field.label} of ${def.name} is required`;
         }
       }

--- a/src/logic/schemaUtils.ts
+++ b/src/logic/schemaUtils.ts
@@ -1,0 +1,35 @@
+export interface SchemaEntry {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+export function parseSchema(val: any): SchemaEntry[] {
+  if (
+    val &&
+    typeof val === 'object' &&
+    val.type === 'object' &&
+    typeof val.properties === 'object'
+  ) {
+    const req: string[] = Array.isArray(val.required) ? val.required : [];
+    return Object.keys(val.properties).map((k) => ({
+      name: k,
+      type: (val.properties as any)[k].type || 'string',
+      required: req.includes(k),
+    }));
+  }
+  return [];
+}
+
+export function buildSchema(entries: SchemaEntry[]): any {
+  const properties: Record<string, { type: string }> = {};
+  const required: string[] = [];
+  for (const e of entries) {
+    if (!e.name) continue;
+    properties[e.name] = { type: e.type };
+    if (e.required) required.push(e.name);
+  }
+  const schema: any = { type: 'object', properties };
+  if (required.length) schema.required = required;
+  return schema;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface Field {
   id: string;
   name: string;
   label: string;
-  type: 'string' | 'integer' | 'float' | 'bool' | 'enum';
+  type: 'string' | 'integer' | 'float' | 'bool' | 'enum' | 'object';
   required?: boolean;
   options?: string[];        // for enum
   default?: unknown;


### PR DESCRIPTION
## Summary
- extend `Field['type']` with `'object'`
- handle object fields in `PropertiesPanel`
- validate required object fields
- add tests covering object field serialization

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_68483e842b0c83278bdd666c01eb87e2