### PR TITLE
Add JSON type and basic tool nodes

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -5,6 +5,7 @@
     "Tool": null,
     "State": null,
     "Text": null,
+    "Json": null,
     "Embeddings": null,
     "OpenAIEmbeddings": "Embeddings",
     "WebSearch": "Tool",
@@ -247,6 +248,49 @@
           "name": "Tool",
           "direction": "output",
           "type": "MCP",
+          "cardinality": "many"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "tool.in",
+      "name": "Tool Input",
+      "tags": ["tool", "json", "input"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "jsonOut",
+          "name": "JSON",
+          "direction": "output",
+          "type": "Json",
+          "cardinality": "many"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "tool.out",
+      "name": "Tool Output",
+      "tags": ["tool", "json", "output"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "jsonIn",
+          "name": "JSON",
+          "direction": "input",
+          "type": "Json",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "Tool",
           "cardinality": "many"
         }
       ],


### PR DESCRIPTION
## Summary
- support `Json` as a first-class pin type
- add `tool.in` and `tool.out` nodes for JSON based tool workflows

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_68483ef37fe88327a3aaa7aea2b72398