### PR TITLE
Move tool metadata to config panel

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -114,6 +114,7 @@
       "id": "workflow.start",
       "name": "Start",
       "tags": ["workflow", "start", "state"],
+      "editors": ["agent"],
       "layout": "singleRow",
       "inputs": [],
       "outputs": [
@@ -132,6 +133,7 @@
       "id": "workflow.end",
       "name": "End",
       "tags": ["workflow", "end", "state"],
+      "editors": ["agent"],
       "layout": "singleRow",
       "inputs": [
         {
@@ -150,6 +152,7 @@
       "id": "tool.start",
       "name": "Tool Start",
       "tags": ["tool", "start"],
+      "editors": ["tool"],
       "layout": "singleRow",
       "inputs": [],
       "outputs": [
@@ -168,6 +171,7 @@
       "id": "tool.end",
       "name": "Tool End",
       "tags": ["tool", "end"],
+      "editors": ["tool"],
       "layout": "singleRow",
       "inputs": [
         {
@@ -186,6 +190,7 @@
       "id": "agent",
       "name": "Agent",
       "tags": ["agent"],
+      "editors": ["agent"],
       "layout": "singleRow",
       "inputs": [
         {
@@ -284,49 +289,6 @@
           "name": "Tool",
           "direction": "output",
           "type": "MCP",
-          "cardinality": "many"
-        }
-      ],
-      "fields": []
-    },
-    {
-      "id": "tool.in",
-      "name": "Tool Input",
-      "tags": ["tool", "json", "input"],
-      "layout": "singleRow",
-      "inputs": [],
-      "outputs": [
-        {
-          "id": "jsonOut",
-          "name": "JSON",
-          "direction": "output",
-          "type": "Json",
-          "cardinality": "many"
-        }
-      ],
-      "fields": []
-    },
-    {
-      "id": "tool.out",
-      "name": "Tool Output",
-      "tags": ["tool", "json", "output"],
-      "layout": "singleRow",
-      "inputs": [
-        {
-          "id": "jsonIn",
-          "name": "JSON",
-          "direction": "input",
-          "type": "Json",
-          "cardinality": "one",
-          "required": true
-        }
-      ],
-      "outputs": [
-        {
-          "id": "toolOut",
-          "name": "Tool",
-          "direction": "output",
-          "type": "Tool",
           "cardinality": "many"
         }
       ],

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -152,12 +152,17 @@
       "tags": ["tool", "start"],
       "layout": "singleRow",
       "inputs": [],
-      "outputs": [],
-      "fields": [
-        { "id": "name", "label": "Name", "type": "string" },
-        { "id": "description", "label": "Description", "type": "string" },
-        { "id": "schema", "label": "JSON Schema", "type": "string" }
-      ]
+      "outputs": [
+        {
+          "id": "stateOut",
+          "name": "State",
+          "direction": "output",
+          "type": "State",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "fields": []
     },
     {
       "id": "tool.end",

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -112,7 +112,7 @@
     },
     {
       "id": "workflow.start",
-      "name": "Start",
+      "name": "Start Agent",
       "tags": ["workflow", "start", "state"],
       "editors": ["agent"],
       "layout": "singleRow",
@@ -131,7 +131,7 @@
     },
     {
       "id": "workflow.end",
-      "name": "End",
+      "name": "End Agent",
       "tags": ["workflow", "end", "state"],
       "editors": ["agent"],
       "layout": "singleRow",
@@ -190,7 +190,7 @@
       "id": "agent",
       "name": "Agent",
       "tags": ["agent"],
-      "editors": ["agent"],
+      "editors": ["agent", "tool"],
       "layout": "singleRow",
       "inputs": [
         {

--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -5,13 +5,48 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
   const name = useWorkflowStore(s => s.workflowName);
   const dirty = useWorkflowStore(s => s.dirty);
   const rename = useWorkflowStore(s => s.renameWorkflow);
+  const toolMeta = useWorkflowStore(s => s.toolMeta);
+  const setToolMeta = useWorkflowStore(s => s.setToolMeta);
+  const renameTool = useWorkflowStore(s => s.renameTool);
 
   const [editing, setEditing] = useState(false);
   const [newName, setNewName] = useState(name);
+  const [cfgOpen, setCfgOpen] = useState(false);
+  const [cfgName, setCfgName] = useState(
+    toolMeta?.name || (name.startsWith('tool:') ? name.slice(5) : '')
+  );
+  const [cfgDesc, setCfgDesc] = useState(toolMeta?.description || '');
+  const [cfgSchema, setCfgSchema] = useState(toolMeta?.schema || '');
 
   const startEdit = () => {
     setNewName(name);
     setEditing(true);
+  };
+
+  const openCfg = () => {
+    setCfgName(toolMeta?.name || (name.startsWith('tool:') ? name.slice(5) : ''));
+    setCfgDesc(toolMeta?.description || '');
+    setCfgSchema(toolMeta?.schema || '');
+    setCfgOpen(true);
+  };
+
+  const saveCfg = () => {
+    if (name.startsWith('tool:')) {
+      const current = toolMeta?.name || name.slice(5);
+      let target = current;
+      if (cfgName && cfgName !== current) {
+        const list = localStorage.getItem('tools');
+        const names = list ? JSON.parse(list) : [];
+        if (names.includes(cfgName)) {
+          alert('Name already exists');
+          return;
+        }
+        renameTool(current, cfgName);
+        target = cfgName;
+      }
+      setToolMeta({ name: target, description: cfgDesc, schema: cfgSchema });
+    }
+    setCfgOpen(false);
   };
 
   const save = () => {
@@ -36,6 +71,14 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
             />
           </svg>
         </button>
+        {name.startsWith('tool:') && (
+          <button className="settings-btn" onClick={openCfg} title="Tool Settings">
+            <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 15.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7z" fill="none" stroke="currentColor" strokeWidth="2" />
+              <path d="M19.4 15a1 1 0 0 0 .1 1.6l.1.1a1 1 0 0 1 0 1.4l-1.4 1.4a1 1 0 0 1-1.4 0l-.1-.1a1 1 0 0 0-1.6.1 7 7 0 0 1-1.2.7 1 1 0 0 0-.6.9V21a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-.2a1 1 0 0 0-.6-.9 7 7 0 0 1-1.2-.7 1 1 0 0 0-1.6-.1l-.1.1a1 1 0 0 1-1.4 0L4 18.1a1 1 0 0 1 0-1.4l.1-.1a1 1 0 0 0 .1-1.6 7 7 0 0 1-.7-1.2 1 1 0 0 0-.9-.6H3a1 1 0 0 1-1-1v-2a1 1 0 0 1 1-1h.2a1 1 0 0 0 .9-.6 7 7 0 0 1 .7-1.2 1 1 0 0 0-.1-1.6l-.1-.1a1 1 0 0 1 0-1.4L5.4 4a1 1 0 0 1 1.4 0l.1.1a1 1 0 0 0 1.6-.1 7 7 0 0 1 1.2-.7 1 1 0 0 0 .6-.9V3a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v.2a1 1 0 0 0 .6.9 7 7 0 0 1 1.2.7 1 1 0 0 0 1.6.1l.1-.1a1 1 0 0 1 1.4 0l1.4 1.4a1 1 0 0 1 0 1.4l-.1.1a1 1 0 0 0 .1 1.6 7 7 0 0 1 .7 1.2 1 1 0 0 0 .9.6H21a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-.2a1 1 0 0 0-.9.6 7 7 0 0 1-.7 1.2z" fill="none" stroke="currentColor" strokeWidth="2" />
+            </svg>
+          </button>
+        )}
         <h2 className="editor-title">
           {name}
           {dirty && <span className="unsaved">*</span>}
@@ -72,6 +115,30 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
             <div className="modal-buttons">
               <button onClick={() => setEditing(false)}>Cancel</button>
               <button onClick={save}>Save</button>
+            </div>
+          </div>
+        </>
+      )}
+      {cfgOpen && (
+        <>
+          <div className="modal-backdrop" onClick={() => setCfgOpen(false)} />
+          <div className="modal" onClick={e => e.stopPropagation()}>
+            <h3>Tool Settings</h3>
+            <label className="field-label">
+              Name
+              <input type="text" value={cfgName} onChange={e => setCfgName(e.target.value)} />
+            </label>
+            <label className="field-label">
+              Description
+              <input type="text" value={cfgDesc} onChange={e => setCfgDesc(e.target.value)} />
+            </label>
+            <label className="field-label">
+              JSON Schema
+              <input type="text" value={cfgSchema} onChange={e => setCfgSchema(e.target.value)} />
+            </label>
+            <div className="modal-buttons">
+              <button onClick={() => setCfgOpen(false)}>Cancel</button>
+              <button onClick={saveCfg}>Save</button>
             </div>
           </div>
         </>

--- a/src/components/EditorPage.tsx
+++ b/src/components/EditorPage.tsx
@@ -3,14 +3,17 @@ import EditorCanvas from './EditorCanvas';
 import PropertiesPanel from './PropertiesPanel';
 import WorkflowManager from './WorkflowManager';
 import EditorHeader from './EditorHeader';
+import { useWorkflowStore } from '../store/workflowStore';
 
 export default function EditorPage({ onBack }: { onBack: () => void }) {
+  const name = useWorkflowStore(s => s.workflowName);
+  const editor: 'agent' | 'tool' = name.startsWith('tool:') ? 'tool' : 'agent';
   return (
     <main className="main editor-page">
       <EditorHeader onBack={onBack} />
       <div className="editor-main">
         <WorkflowManager />
-        <NodePalette />
+        <NodePalette editor={editor} />
         <EditorCanvas />
         <PropertiesPanel />
       </div>

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -2,7 +2,10 @@ import { useMemo, useState } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
 import { validateWorkflow } from '../logic/pinValidation';
 
-export default function NodePalette() {
+interface Props {
+  editor: 'agent' | 'tool';
+}
+export default function NodePalette({ editor }: Props) {
   const nodeTypes = useWorkflowStore((s) => s.nodeTypes);
   const nodes = useWorkflowStore((s) => s.nodes);
   const edges = useWorkflowStore((s) => s.edges);
@@ -15,10 +18,11 @@ export default function NodePalette() {
     const q = query.toLowerCase();
     return nodeTypes.filter(
       (nt) =>
-        nt.name.toLowerCase().includes(q) ||
-        nt.tags.some((t) => t.toLowerCase().includes(q))
+        (!nt.editors || nt.editors.includes(editor)) &&
+        (nt.name.toLowerCase().includes(q) ||
+          nt.tags.some((t) => t.toLowerCase().includes(q)))
     );
-  }, [nodeTypes, query]);
+  }, [nodeTypes, query, editor]);
 
   return (
     <div className="palette-wrapper">
@@ -77,7 +81,13 @@ export default function NodePalette() {
         className="palette-toggle validate-toggle"
         aria-label="Validate workflow"
         onClick={() => {
-          const err = validateWorkflow(nodes, edges, nodeTypes, hierarchy);
+          const err = validateWorkflow(
+            nodes,
+            edges,
+            nodeTypes,
+            hierarchy,
+            editor === 'tool' ? 'tool' : 'agent'
+          );
           if (err) {
             setToast(err, 'error');
           } else {

--- a/src/logic/__tests__/pinValidation.test.ts
+++ b/src/logic/__tests__/pinValidation.test.ts
@@ -140,4 +140,17 @@ describe('validateWorkflow', () => {
     ];
     expect(validateWorkflow(nodes, edges, nodeTypes, hierarchy)).toBeNull();
   });
+
+  it('validates tool workflows with start and end', () => {
+    const nodes: Record<string, NodeInstance> = {
+      start: makeNode('tool.start', 'start'),
+      end: makeNode('tool.end', 'end')
+    };
+    const edges: EdgeInstance[] = [
+      { id: 'e1', from: { uuid: 'start', pin: 'stateOut' }, to: { uuid: 'end', pin: 'stateIn' } }
+    ];
+    expect(
+      validateWorkflow(nodes, edges, nodeTypes, hierarchy, 'tool')
+    ).toBeNull();
+  });
 });

--- a/src/theme.css
+++ b/src/theme.css
@@ -449,6 +449,12 @@
   vertical-align: middle;
   margin-left: 0.25rem;
 }
+.editor-header .settings-btn {
+  position: absolute;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+}
 .editor-header .editor-title {
   margin: 0;
   display: flex;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,3 +42,15 @@ export interface EdgeInstance {
   from: { uuid: string; pin: string };
   to: { uuid: string; pin: string };
 }
+
+export interface ToolMeta {
+  name: string;
+  description: string;
+  schema: string;
+}
+
+export interface ToolData {
+  meta: ToolMeta;
+  nodes: Record<string, NodeInstance>;
+  edges: EdgeInstance[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface NodeType {
   inputs: Pin[];
   outputs: Pin[];
   fields: Field[];
+  editors?: ('tool' | 'agent')[];
 }
 
 export interface NodeInstance {


### PR DESCRIPTION
## Summary
- shift Tool Start node metadata to a new configuration panel
- edit tool settings from editor header
- store tool metadata separately from nodes
- expose tool meta actions in the workflow store
- adjust styles for new settings button

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_68484afb46288327a4b5db058609d5a7