### PR TITLE
Add visual JSON schema editor

### DIFF
--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -123,7 +123,7 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
       {cfgOpen && (
         <>
           <div className="modal-backdrop" onClick={() => setCfgOpen(false)} />
-          <div className="modal" onClick={e => e.stopPropagation()}>
+          <div className="modal modal-large" onClick={e => e.stopPropagation()}>
             <h3>Tool Settings</h3>
             <label className="field-label">
               Name

--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useWorkflowStore } from '../store/workflowStore';
+import SchemaEditor from './SchemaEditor';
 
 export default function EditorHeader({ onBack }: { onBack: () => void }) {
   const name = useWorkflowStore(s => s.workflowName);
@@ -134,7 +135,7 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
             </label>
             <label className="field-label">
               JSON Schema
-              <input type="text" value={cfgSchema} onChange={e => setCfgSchema(e.target.value)} />
+              <SchemaEditor value={cfgSchema} onChange={setCfgSchema} />
             </label>
             <div className="modal-buttons">
               <button onClick={() => setCfgOpen(false)}>Cancel</button>

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -61,12 +61,8 @@ const parseEnum = (type: string, val: string): any => {
 
 export default function SchemaEditor({ value, onChange }: Props) {
   const [fields, setFields] = useState<FieldDef[]>([]);
-  const [adding, setAdding] = useState(false);
-  const [newField, setNewField] = useState<FieldDef>(defaultField());
   const [enumInputs, setEnumInputs] = useState<Record<number, string>>({});
   const [enumErrors, setEnumErrors] = useState<Record<number, string>>({});
-  const [newEnumInput, setNewEnumInput] = useState('');
-  const [newEnumError, setNewEnumError] = useState('');
 
   // parse incoming value
   useEffect(() => {
@@ -147,8 +143,7 @@ export default function SchemaEditor({ value, onChange }: Props) {
   };
 
   const addField = () => {
-    setNewField(defaultField());
-    setAdding(true);
+    updateFields(prev => [...prev, defaultField()]);
   };
 
   const removeField = (idx: number) => updateFields(prev => prev.filter((_, i) => i !== idx));
@@ -258,115 +253,6 @@ export default function SchemaEditor({ value, onChange }: Props) {
         ))}
       </ul>
       <button type="button" onClick={addField}>Add Field</button>
-      {adding && (
-        <>
-          <div className="modal-backdrop" onClick={() => setAdding(false)} />
-          <div className="modal" onClick={e => e.stopPropagation()}>
-            <h3>Add Field</h3>
-            <label className="field-label">
-              Name
-              <input
-                type="text"
-                value={newField.name}
-                onChange={e => setNewField({ ...newField, name: e.target.value })}
-              />
-            </label>
-            <label className="field-label">
-              Description
-              <input
-                type="text"
-                value={newField.description}
-                onChange={e =>
-                  setNewField({ ...newField, description: e.target.value })
-                }
-              />
-            </label>
-            <label className="field-label">
-              Enum Values
-              <div className="enum-tags">
-                {newField.enums.map((val, j) => (
-                  <span className="enum-tag" key={j}>
-                    {val}
-                    <button
-                      type="button"
-                      className="delete-btn"
-                      onClick={() =>
-                        setNewField({
-                          ...newField,
-                          enums: newField.enums.filter((_, i) => i !== j)
-                        })
-                      }
-                      aria-label="Delete enum"
-                    >
-                      <svg width="10" height="10" viewBox="0 0 12 12" aria-hidden="true">
-                        <line x1="1" y1="1" x2="11" y2="11" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                        <line x1="11" y1="1" x2="1" y2="11" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                      </svg>
-                    </button>
-                  </span>
-                ))}
-              </div>
-              <div className="enum-item">
-                <input
-                  type="text"
-                  value={newEnumInput}
-                  onChange={e => setNewEnumInput(e.target.value)}
-                />
-                <button
-                  type="button"
-                  className="add-btn"
-                  onClick={() => {
-                    if (!newEnumInput.trim()) return;
-                    if (!isValidEnum(newField.type, newEnumInput)) {
-                      setNewEnumError('Invalid value');
-                      return;
-                    }
-                    setNewField({
-                      ...newField,
-                      enums: [...newField.enums, newEnumInput.trim()]
-                    });
-                    setNewEnumInput('');
-                    setNewEnumError('');
-                  }}
-                  aria-label="Add enum"
-                >
-                  <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
-                    <line x1="1" y1="6" x2="11" y2="6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                    <line x1="6" y1="1" x2="6" y2="11" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-                  </svg>
-                </button>
-              </div>
-              {newEnumError && <div className="enum-error">{newEnumError}</div>}
-            </label>
-            <label className="field-label">
-              Type
-              <select
-                value={newField.type}
-                onChange={e => setNewField({ ...newField, type: e.target.value })}
-              >
-                <option value="string">string</option>
-                <option value="number">number</option>
-                <option value="object">object</option>
-                <option value="array">array</option>
-                <option value="boolean">boolean</option>
-                <option value="null">null</option>
-              </select>
-            </label>
-            <div className="modal-buttons">
-              <button onClick={() => setAdding(false)}>Cancel</button>
-              <button
-                onClick={() => {
-                  if (!newField.name) return;
-                  updateFields(prev => [...prev, newField]);
-                  setAdding(false);
-                }}
-              >
-                Add
-              </button>
-            </div>
-          </div>
-        </>
-      )}
     </div>
   );
 }

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -162,6 +162,18 @@ export default function SchemaEditor({ value, onChange }: Props) {
                 placeholder={`Field ${i + 1}`}
                 onChange={e => updateField(i, 'name', e.target.value)}
               />
+              <select
+                className="field-type"
+                value={f.type}
+                onChange={e => updateField(i, 'type', e.target.value)}
+              >
+                <option value="string">string</option>
+                <option value="number">number</option>
+                <option value="object">object</option>
+                <option value="array">array</option>
+                <option value="boolean">boolean</option>
+                <option value="null">null</option>
+              </select>
               <button
                 type="button"
                 className="delete-btn"
@@ -233,17 +245,6 @@ export default function SchemaEditor({ value, onChange }: Props) {
                   </button>
                 </div>
                 {enumErrors[i] && <div className="enum-error">{enumErrors[i]}</div>}
-              </label>
-              <label className="field-label">
-                Type
-                <select value={f.type} onChange={e => updateField(i, 'type', e.target.value)}>
-                  <option value="string">string</option>
-                  <option value="number">number</option>
-                  <option value="object">object</option>
-                  <option value="array">array</option>
-                  <option value="boolean">boolean</option>
-                  <option value="null">null</option>
-                </select>
               </label>
             </div>
           </details>

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -81,36 +81,81 @@ export default function SchemaEditor({ value, onChange }: Props) {
 
   return (
     <div className="schema-editor">
-      {fields.map((f, i) => (
-        <div className="schema-field" key={i}>
-          <input
-            placeholder="Name"
-            value={f.name}
-            onChange={e => updateField(i, 'name', e.target.value)}
-          />
-          <select value={f.type} onChange={e => updateField(i, 'type', e.target.value)}>
-            <option value="string">string</option>
-            <option value="number">number</option>
-            <option value="object">object</option>
-            <option value="array">array</option>
-            <option value="boolean">boolean</option>
-            <option value="null">null</option>
-          </select>
-          <input
-            placeholder="Description"
-            value={f.description}
-            onChange={e => updateField(i, 'description', e.target.value)}
-          />
-          <input
-            placeholder="Enum (comma separated)"
-            value={f.enumVals}
-            onChange={e => updateField(i, 'enumVals', e.target.value)}
-          />
-          <button type="button" className="delete-btn" onClick={() => removeField(i)}>
-            🗑️
-          </button>
-        </div>
-      ))}
+      <ul>
+        {fields.map((f, i) => (
+          <li className="schema-field" key={i}>
+            <details>
+            <summary className="field-summary">
+              <span>{f.name || `Field ${i + 1}`}</span>
+              <button
+                type="button"
+                className="delete-btn"
+                onClick={() => removeField(i)}
+                aria-label="Delete field"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+                  <line
+                    x1="1"
+                    y1="1"
+                    x2="11"
+                    y2="11"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                  <line
+                    x1="11"
+                    y1="1"
+                    x2="1"
+                    y2="11"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </summary>
+            <div className="field-body">
+              <label className="field-label">
+                Name
+                <input
+                  type="text"
+                  value={f.name}
+                  onChange={e => updateField(i, 'name', e.target.value)}
+                />
+              </label>
+              <label className="field-label">
+                Description
+                <input
+                  type="text"
+                  value={f.description}
+                  onChange={e => updateField(i, 'description', e.target.value)}
+                />
+              </label>
+              <label className="field-label">
+                Enum (comma separated)
+                <input
+                  type="text"
+                  value={f.enumVals}
+                  onChange={e => updateField(i, 'enumVals', e.target.value)}
+                />
+              </label>
+              <label className="field-label">
+                Type
+                <select value={f.type} onChange={e => updateField(i, 'type', e.target.value)}>
+                  <option value="string">string</option>
+                  <option value="number">number</option>
+                  <option value="object">object</option>
+                  <option value="array">array</option>
+                  <option value="boolean">boolean</option>
+                  <option value="null">null</option>
+                </select>
+              </label>
+            </div>
+          </details>
+          </li>
+        ))}
+      </ul>
       <button type="button" onClick={addField}>Add Field</button>
       {adding && (
         <>

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -155,6 +155,9 @@ export default function SchemaEditor({ value, onChange }: Props) {
           <li className="schema-field" key={i}>
             <details>
             <summary className="field-summary">
+              <svg className="toggle-icon" width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+                <polyline points="4,2 8,6 4,10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
               <input
                 className="field-name"
                 type="text"

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -9,12 +9,14 @@ interface FieldDef {
   name: string;
   type: string;
   description: string;
+  enumVals: string;
 }
 
 const defaultField = (): FieldDef => ({
   name: '',
   type: 'string',
-  description: ''
+  description: '',
+  enumVals: ''
 });
 
 export default function SchemaEditor({ value, onChange }: Props) {
@@ -29,7 +31,8 @@ export default function SchemaEditor({ value, onChange }: Props) {
       const arr: FieldDef[] = Object.entries(obj).map(([key, def]: any) => ({
         name: key,
         type: def.type || 'string',
-        description: def.description || ''
+        description: def.description || '',
+        enumVals: Array.isArray(def.enum) ? def.enum.join(', ') : ''
       }));
       if (arr.length === 0) arr.push(defaultField());
       setFields(arr);
@@ -44,6 +47,10 @@ export default function SchemaEditor({ value, onChange }: Props) {
       if (!f.name) return;
       const prop: any = { type: f.type };
       if (f.description) prop.description = f.description;
+      if (f.enumVals) {
+        const vals = f.enumVals.split(',').map(v => v.trim()).filter(Boolean);
+        if (vals.length) prop.enum = vals;
+      }
       obj[f.name] = prop;
     });
     return JSON.stringify(obj, null, 2);
@@ -94,6 +101,11 @@ export default function SchemaEditor({ value, onChange }: Props) {
             value={f.description}
             onChange={e => updateField(i, 'description', e.target.value)}
           />
+          <input
+            placeholder="Enum (comma separated)"
+            value={f.enumVals}
+            onChange={e => updateField(i, 'enumVals', e.target.value)}
+          />
           <button type="button" className="delete-btn" onClick={() => removeField(i)}>
             🗑️
           </button>
@@ -120,6 +132,16 @@ export default function SchemaEditor({ value, onChange }: Props) {
                 value={newField.description}
                 onChange={e =>
                   setNewField({ ...newField, description: e.target.value })
+                }
+              />
+            </label>
+            <label className="field-label">
+              Enum (comma separated)
+              <input
+                type="text"
+                value={newField.enumVals}
+                onChange={e =>
+                  setNewField({ ...newField, enumVals: e.target.value })
                 }
               />
             </label>

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (val: string) => void;
+}
+
+interface FieldDef {
+  name: string;
+  type: string;
+  description: string;
+  enumText: string;
+}
+
+const defaultField = (): FieldDef => ({
+  name: '',
+  type: 'string',
+  description: '',
+  enumText: ''
+});
+
+export default function SchemaEditor({ value, onChange }: Props) {
+  const [fields, setFields] = useState<FieldDef[]>([]);
+
+  // parse incoming value
+  useEffect(() => {
+    try {
+      const obj = JSON.parse(value || '{}');
+      const arr: FieldDef[] = Object.entries(obj).map(([key, def]: any) => ({
+        name: key,
+        type: def.type || 'string',
+        description: def.description || '',
+        enumText: Array.isArray(def.enum) ? def.enum.join(', ') : ''
+      }));
+      if (arr.length === 0) arr.push(defaultField());
+      setFields(arr);
+    } catch {
+      setFields([defaultField()]);
+    }
+  }, [value]);
+
+  const buildSchema = (defs: FieldDef[]) => {
+    const obj: Record<string, any> = {};
+    defs.forEach(f => {
+      if (!f.name) return;
+      const prop: any = { type: f.type };
+      if (f.description) prop.description = f.description;
+      if (f.enumText.trim()) {
+        prop.enum = f.enumText.split(',').map(s => s.trim()).filter(Boolean);
+      }
+      obj[f.name] = prop;
+    });
+    return JSON.stringify(obj, null, 2);
+  };
+
+  const updateFields = (updater: (prev: FieldDef[]) => FieldDef[]) => {
+    setFields(prev => {
+      const next = updater(prev);
+      onChange(buildSchema(next));
+      return next;
+    });
+  };
+
+  const updateField = (idx: number, key: keyof FieldDef, val: string) => {
+    updateFields(prev => {
+      const next = prev.slice();
+      next[idx] = { ...next[idx], [key]: val };
+      return next;
+    });
+  };
+
+  const addField = () => updateFields(prev => [...prev, defaultField()]);
+
+  const removeField = (idx: number) => updateFields(prev => prev.filter((_, i) => i !== idx));
+
+  return (
+    <div className="schema-editor">
+      {fields.map((f, i) => (
+        <div className="schema-field" key={i}>
+          <input
+            placeholder="Name"
+            value={f.name}
+            onChange={e => updateField(i, 'name', e.target.value)}
+          />
+          <select value={f.type} onChange={e => updateField(i, 'type', e.target.value)}>
+            <option value="string">string</option>
+            <option value="number">number</option>
+            <option value="integer">integer</option>
+            <option value="boolean">boolean</option>
+          </select>
+          <input
+            placeholder="Description"
+            value={f.description}
+            onChange={e => updateField(i, 'description', e.target.value)}
+          />
+          <input
+            placeholder="Enum values"
+            value={f.enumText}
+            onChange={e => updateField(i, 'enumText', e.target.value)}
+          />
+          <button type="button" className="delete-btn" onClick={() => removeField(i)}>
+            🗑️
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addField}>Add Field</button>
+    </div>
+  );
+}

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -155,7 +155,13 @@ export default function SchemaEditor({ value, onChange }: Props) {
           <li className="schema-field" key={i}>
             <details>
             <summary className="field-summary">
-              <span>{f.name || `Field ${i + 1}`}</span>
+              <input
+                className="field-name"
+                type="text"
+                value={f.name}
+                placeholder={`Field ${i + 1}`}
+                onChange={e => updateField(i, 'name', e.target.value)}
+              />
               <button
                 type="button"
                 className="delete-btn"
@@ -185,14 +191,6 @@ export default function SchemaEditor({ value, onChange }: Props) {
               </button>
             </summary>
             <div className="field-body">
-              <label className="field-label">
-                Name
-                <input
-                  type="text"
-                  value={f.name}
-                  onChange={e => updateField(i, 'name', e.target.value)}
-                />
-              </label>
               <label className="field-label">
                 Description
                 <input

--- a/src/components/SchemaEditor.tsx
+++ b/src/components/SchemaEditor.tsx
@@ -162,6 +162,13 @@ export default function SchemaEditor({ value, onChange }: Props) {
                 placeholder={`Field ${i + 1}`}
                 onChange={e => updateField(i, 'name', e.target.value)}
               />
+              <input
+                className="field-desc"
+                type="text"
+                value={f.description}
+                placeholder="Description"
+                onChange={e => updateField(i, 'description', e.target.value)}
+              />
               <select
                 className="field-type"
                 value={f.type}
@@ -203,14 +210,6 @@ export default function SchemaEditor({ value, onChange }: Props) {
               </button>
             </summary>
             <div className="field-body">
-              <label className="field-label">
-                Description
-                <input
-                  type="text"
-                  value={f.description}
-                  onChange={e => updateField(i, 'description', e.target.value)}
-                />
-              </label>
               <label className="field-label">
                 Enum Values
                 <div className="enum-tags">

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -184,7 +184,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
       {editing && (
         <>
           <div className="modal-backdrop" onClick={() => setEditing(null)} />
-          <div className="modal" onClick={e => e.stopPropagation()}>
+          <div className="modal modal-large" onClick={e => e.stopPropagation()}>
             <h3>Edit Tool</h3>
             <label className="field-label">
               Name

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import SchemaEditor from './SchemaEditor';
 import { v4 as uuid } from 'uuid';
 import type { NodeInstance, EdgeInstance, ToolData, ToolMeta } from '../types';
 
@@ -195,7 +196,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
             </label>
             <label className="field-label">
               JSON Schema
-              <input type="text" value={metaSchema} onChange={e => setMetaSchema(e.target.value)} />
+              <SchemaEditor value={metaSchema} onChange={setMetaSchema} />
             </label>
             <div className="modal-buttons">
               <button onClick={() => setEditing(null)}>Cancel</button>

--- a/src/theme.css
+++ b/src/theme.css
@@ -177,6 +177,11 @@
   width: 100%;
   margin-top: 0.5rem;
 }
+
+/* Override modal input margin for compact schema editor summary fields */
+.schema-editor .field-summary input[type="text"] {
+  margin-top: 0;
+}
 .modal-buttons {
   display: flex;
   justify-content: flex-end;

--- a/src/theme.css
+++ b/src/theme.css
@@ -562,16 +562,36 @@
   flex-direction: column;
   gap: 4px;
 }
-.schema-field {
+.schema-editor ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 4px;
 }
-.schema-field input,
-.schema-field select {
-  flex: 1;
+.schema-field details {
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 4px;
 }
-.schema-field .delete-btn {
+.field-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+}
+.field-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+}
+.field-body input,
+.field-body select {
+  width: 100%;
+}
+.delete-btn {
   background: none;
   border: none;
   color: #d55;

--- a/src/theme.css
+++ b/src/theme.css
@@ -615,7 +615,7 @@
 details[open] .field-summary .toggle-icon {
   transform: rotate(90deg);
 }
-.field-summary .field-name {
+.schema-editor .field-summary .field-name {
   font-weight: bold;
   flex: 0 0 auto;
   margin-right: 4px;
@@ -628,15 +628,15 @@ details[open] .field-summary .toggle-icon {
   padding: 2px 4px;
   transition: width 0.15s ease;
 }
-.field-summary .field-name:hover {
+.schema-editor .field-summary .field-name:hover {
   outline: 1px solid var(--accent);
 }
-.field-summary .field-name:focus {
+.schema-editor .field-summary .field-name:focus {
   outline: 1px solid var(--accent);
   width: 12ch;
 }
 
-.field-summary .field-desc {
+.schema-editor .field-summary .field-desc {
   flex: 1 1 auto;
   margin-right: auto;
   min-width: 12ch;
@@ -649,10 +649,10 @@ details[open] .field-summary .toggle-icon {
   padding: 2px 4px;
   transition: width 0.15s ease;
 }
-.field-summary .field-desc:hover {
+.schema-editor .field-summary .field-desc:hover {
   outline: 1px solid var(--accent);
 }
-.field-summary .field-desc:focus {
+.schema-editor .field-summary .field-desc:focus {
   outline: 1px solid var(--accent);
   width: 24ch;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -660,17 +660,24 @@ details[open] .field-summary .toggle-icon {
 .field-summary .field-type {
   margin-left: auto;
   margin-right: 4px;
-  padding: 1px 3px;
+  padding: 2px 4px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
-  font-size: 0.8rem;
+  font-size: 1rem;
+  line-height: 1;
+  height: calc(1em + 4px);
   width: auto;
   align-self: center;
 }
 .field-summary .delete-btn {
   margin-left: 0;
+  width: calc(1em + 4px);
+  height: calc(1em + 4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .field-body {
   display: flex;

--- a/src/theme.css
+++ b/src/theme.css
@@ -696,6 +696,7 @@ details[open] .field-summary .toggle-icon {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  padding: 0 4px 4px;
   margin-top: 4px;
 }
 .field-body select {

--- a/src/theme.css
+++ b/src/theme.css
@@ -588,12 +588,13 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
 }
 .schema-field details {
   border: 1px solid var(--accent);
   border-radius: 4px;
   padding: 4px;
+  background: #6661;
 }
 .field-summary {
   display: flex;
@@ -644,7 +645,7 @@
   border-radius: 12px;
   padding: 2px 6px;
   font-size: 0.9rem;
-  gap: 2px;
+  gap: 6px;
 }
 .enum-tag button {
   background: none;
@@ -673,6 +674,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: center;
   cursor: pointer;
 }
 .enum-error {

--- a/src/theme.css
+++ b/src/theme.css
@@ -621,7 +621,8 @@ details[open] .field-summary .toggle-icon {
   margin-right: 4px;
   width: 12ch;
   height: 24px;
-  line-height: 20px;
+  line-height: 18px;
+  vertical-align: middle;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -644,7 +645,8 @@ details[open] .field-summary .toggle-icon {
   min-width: 12ch;
   width: 12ch;
   height: 24px;
-  line-height: 20px;
+  line-height: 18px;
+  vertical-align: middle;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);

--- a/src/theme.css
+++ b/src/theme.css
@@ -596,17 +596,30 @@
   padding: 4px;
   background: #6661;
 }
+.schema-field summary {
+  list-style: none;
+}
+.schema-field summary::-webkit-details-marker {
+  display: none;
+}
 .field-summary {
   display: flex;
   align-items: center;
   gap: 4px;
   cursor: pointer;
 }
+.field-summary .toggle-icon {
+  transition: transform 0.2s;
+  flex: none;
+}
+details[open] .field-summary .toggle-icon {
+  transform: rotate(90deg);
+}
 .field-summary .field-name {
   font-weight: bold;
-  flex: none;
+  flex: 0 0 8ch;
   margin-right: 4px;
-  width: 12ch !important;
+  width: 8ch;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -618,15 +631,15 @@
 .field-summary .field-name:hover {
   outline: 1px solid var(--accent);
 }
-.field-summary .field-name:focus {
+.field-summary:focus-within .field-name {
   outline: 1px solid var(--accent);
-  width: 20ch !important;
+  width: 14ch;
 }
 
 .field-summary .field-desc {
-  flex: none;
+  flex: 1 1 auto;
   margin-right: auto;
-  width: 20ch !important;
+  min-width: 16ch;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -638,9 +651,8 @@
 .field-summary .field-desc:hover {
   outline: 1px solid var(--accent);
 }
-.field-summary .field-desc:focus {
+.field-summary:focus-within .field-desc {
   outline: 1px solid var(--accent);
-  width: 32ch !important;
 }
 
 .field-summary .field-type {

--- a/src/theme.css
+++ b/src/theme.css
@@ -619,7 +619,7 @@ details[open] .field-summary .toggle-icon {
   font-weight: bold;
   flex: 0 0 auto;
   margin-right: 4px;
-  width: 6ch;
+  width: 12ch;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -633,7 +633,7 @@ details[open] .field-summary .toggle-icon {
 }
 .schema-editor .field-summary .field-name:focus {
   outline: 1px solid var(--accent);
-  width: 12ch;
+  width: 24ch;
 }
 
 .schema-editor .field-summary .field-desc {

--- a/src/theme.css
+++ b/src/theme.css
@@ -168,9 +168,9 @@
   min-width: 240px;
 }
 .modal-large {
-  width: 90vw;
-  max-width: 800px;
-  max-height: 90vh;
+  width: 95vw;
+  max-width: 1000px;
+  max-height: 95vh;
   overflow-y: auto;
 }
 .modal input[type="text"] {
@@ -628,5 +628,20 @@
   border: none;
   color: #d55;
   cursor: pointer;
+}
+
+/* Enum editing */
+.enum-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.enum-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.enum-item input {
+  flex: 1;
 }
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -604,15 +604,33 @@
 }
 .field-summary .field-name {
   font-weight: bold;
-  flex: 1;
+  flex: 0 0 auto;
+  width: 8ch;
   border: none;
   background: transparent;
   color: var(--fg);
   font-size: 1rem;
   padding: 2px;
+  transition: width 0.2s ease;
+}
+.field-summary .field-name:hover {
+  outline: 1px solid var(--accent);
 }
 .field-summary .field-name:focus {
   outline: 1px solid var(--accent);
+  width: 100%;
+  flex: 1;
+}
+
+.field-summary .field-type {
+  margin-left: 4px;
+  padding: 2px 4px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 0.9rem;
+  width: auto;
 }
 .field-body {
   display: flex;
@@ -658,6 +676,7 @@
   padding: 2px 6px;
   font-size: 0.9rem;
   gap: 6px;
+  line-height: 1;
 }
 .enum-tag button {
   background: none;
@@ -677,6 +696,7 @@
 }
 .enum-item input {
   flex: 1;
+  height: 24px;
 }
 .add-btn {
   background: var(--accent);
@@ -688,7 +708,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  align-self: center;
   cursor: pointer;
   line-height: 0;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -605,7 +605,7 @@
 .field-summary .field-name {
   font-weight: bold;
   flex: 0 0 auto;
-  width: 8ch;
+  width: 5ch;
   border: none;
   background: transparent;
   color: var(--fg);
@@ -624,12 +624,12 @@
 
 .field-summary .field-type {
   margin-left: 4px;
-  padding: 2px 4px;
+  padding: 1px 3px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   width: auto;
 }
 .field-body {

--- a/src/theme.css
+++ b/src/theme.css
@@ -758,6 +758,8 @@ details[open] .field-summary .toggle-icon {
 .enum-item input {
   flex: 1;
   height: 24px;
+  box-sizing: border-box;
+  line-height: 24px;
 }
 .add-btn {
   background: var(--accent);
@@ -766,6 +768,7 @@ details[open] .field-summary .toggle-icon {
   border-radius: 4px;
   width: 24px;
   height: 24px;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -604,13 +604,14 @@
 }
 .field-summary .field-name {
   font-weight: bold;
-  flex: none;
+  flex: none; margin-right: auto;
   width: 4ch !important;
-  border: none;
-  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  padding: 2px;
+  padding: 2px 4px;
   transition: width 0.15s ease;
 }
 .field-summary .field-name:hover {
@@ -622,7 +623,8 @@
 }
 
 .field-summary .field-type {
-  margin-left: 4px;
+  margin-left: auto;
+  margin-right: 4px;
   padding: 1px 3px;
   border: 1px solid var(--accent);
   border-radius: 4px;
@@ -630,6 +632,9 @@
   color: var(--fg);
   font-size: 0.8rem;
   width: auto;
+}
+.field-summary .delete-btn {
+  margin-left: 0;
 }
 .field-body {
   display: flex;

--- a/src/theme.css
+++ b/src/theme.css
@@ -627,8 +627,8 @@ details[open] .field-summary .toggle-icon {
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  line-height: 20px;
-  padding: 2px 4px;
+  line-height: 24px;
+  padding: 0 4px;
   transition: width 0.15s ease;
 }
 .schema-editor .field-summary .field-name:hover {
@@ -651,8 +651,8 @@ details[open] .field-summary .toggle-icon {
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  line-height: 20px;
-  padding: 2px 4px;
+  line-height: 24px;
+  padding: 0 4px;
   transition: width 0.15s ease;
 }
 .schema-editor .field-summary .field-desc:hover {
@@ -666,12 +666,13 @@ details[open] .field-summary .toggle-icon {
 .field-summary .field-type {
   margin-left: auto;
   margin-right: 4px;
-  padding: 2px 4px;
+  padding: 0 4px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
+  line-height: 24px;
   height: 24px;
   box-sizing: border-box;
   width: auto;

--- a/src/theme.css
+++ b/src/theme.css
@@ -604,8 +604,9 @@
 }
 .field-summary .field-name {
   font-weight: bold;
-  flex: none; margin-right: auto;
-  width: 4ch !important;
+  flex: none;
+  margin-right: 4px;
+  width: 12ch !important;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -619,7 +620,27 @@
 }
 .field-summary .field-name:focus {
   outline: 1px solid var(--accent);
-  width: 12ch !important;
+  width: 20ch !important;
+}
+
+.field-summary .field-desc {
+  flex: none;
+  margin-right: auto;
+  width: 20ch !important;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 1rem;
+  padding: 2px 4px;
+  transition: width 0.15s ease;
+}
+.field-summary .field-desc:hover {
+  outline: 1px solid var(--accent);
+}
+.field-summary .field-desc:focus {
+  outline: 1px solid var(--accent);
+  width: 32ch !important;
 }
 
 .field-summary .field-type {

--- a/src/theme.css
+++ b/src/theme.css
@@ -605,7 +605,7 @@
 .field-summary .field-name {
   font-weight: bold;
   flex: none;
-  width: 4ch;
+  width: 4ch !important;
   border: none;
   background: transparent;
   color: var(--fg);
@@ -618,7 +618,7 @@
 }
 .field-summary .field-name:focus {
   outline: 1px solid var(--accent);
-  width: 12ch;
+  width: 12ch !important;
 }
 
 .field-summary .field-type {

--- a/src/theme.css
+++ b/src/theme.css
@@ -556,3 +556,25 @@
   margin-left: 8px;
 }
 
+/* Schema Editor */
+.schema-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.schema-field {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.schema-field input,
+.schema-field select {
+  flex: 1;
+}
+.schema-field .delete-btn {
+  background: none;
+  border: none;
+  color: #d55;
+  cursor: pointer;
+}
+

--- a/src/theme.css
+++ b/src/theme.css
@@ -620,6 +620,8 @@ details[open] .field-summary .toggle-icon {
   flex: 0 0 auto;
   margin-right: 4px;
   width: 12ch;
+  height: 24px;
+  line-height: 20px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -641,6 +643,8 @@ details[open] .field-summary .toggle-icon {
   margin-right: auto;
   min-width: 12ch;
   width: 12ch;
+  height: 24px;
+  line-height: 20px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);

--- a/src/theme.css
+++ b/src/theme.css
@@ -621,8 +621,8 @@ details[open] .field-summary .toggle-icon {
   margin-right: 4px;
   width: 12ch;
   height: 24px;
-  line-height: 18px;
-  vertical-align: middle;
+  line-height: 20px;
+  box-sizing: border-box;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -645,8 +645,8 @@ details[open] .field-summary .toggle-icon {
   min-width: 12ch;
   width: 12ch;
   height: 24px;
-  line-height: 18px;
-  vertical-align: middle;
+  line-height: 20px;
+  box-sizing: border-box;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -674,6 +674,7 @@ details[open] .field-summary .toggle-icon {
   font-size: 1rem;
   line-height: 1;
   height: 24px;
+  box-sizing: border-box;
   width: auto;
   align-self: center;
 }
@@ -681,6 +682,7 @@ details[open] .field-summary .toggle-icon {
   margin-left: 0;
   width: 24px;
   height: 24px;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -621,14 +621,13 @@ details[open] .field-summary .toggle-icon {
   margin-right: 4px;
   width: 12ch;
   height: 24px;
-  line-height: 24px;
   box-sizing: border-box;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  padding: 0 4px;
+  padding: 2px 4px;
   transition: width 0.15s ease;
 }
 .schema-editor .field-summary .field-name:hover {
@@ -645,14 +644,13 @@ details[open] .field-summary .toggle-icon {
   min-width: 12ch;
   width: 12ch;
   height: 24px;
-  line-height: 24px;
   box-sizing: border-box;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  padding: 0 4px;
+  padding: 2px 4px;
   transition: width 0.15s ease;
 }
 .schema-editor .field-summary .field-desc:hover {
@@ -666,13 +664,12 @@ details[open] .field-summary .toggle-icon {
 .field-summary .field-type {
   margin-left: auto;
   margin-right: 4px;
-  padding: 0 4px;
+  padding: 2px 4px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  line-height: 24px;
   height: 24px;
   box-sizing: border-box;
   width: auto;

--- a/src/theme.css
+++ b/src/theme.css
@@ -667,14 +667,14 @@ details[open] .field-summary .toggle-icon {
   color: var(--fg);
   font-size: 1rem;
   line-height: 1;
-  height: calc(1em + 4px);
+  height: 24px;
   width: auto;
   align-self: center;
 }
 .field-summary .delete-btn {
   margin-left: 0;
-  width: calc(1em + 4px);
-  height: calc(1em + 4px);
+  width: 24px;
+  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/theme.css
+++ b/src/theme.css
@@ -593,7 +593,6 @@
 .schema-field details {
   border: 1px solid var(--accent);
   border-radius: 4px;
-  padding: 4px;
   background: #6661;
 }
 .schema-field summary {
@@ -607,6 +606,7 @@
   align-items: center;
   gap: 4px;
   cursor: pointer;
+  padding: 4px;
 }
 .field-summary .toggle-icon {
   transition: transform 0.2s;
@@ -627,6 +627,7 @@ details[open] .field-summary .toggle-icon {
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
+  line-height: 20px;
   padding: 2px 4px;
   transition: width 0.15s ease;
 }
@@ -650,6 +651,7 @@ details[open] .field-summary .toggle-icon {
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
+  line-height: 20px;
   padding: 2px 4px;
   transition: width 0.15s ease;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -631,10 +631,29 @@
 }
 
 /* Enum editing */
-.enum-list {
+.enum-tags {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
   gap: 4px;
+  margin-bottom: 4px;
+}
+.enum-tag {
+  display: inline-flex;
+  align-items: center;
+  background: #6662;
+  border-radius: 12px;
+  padding: 2px 6px;
+  font-size: 0.9rem;
+  gap: 2px;
+}
+.enum-tag button {
+  background: none;
+  border: none;
+  color: #d55;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
 }
 .enum-item {
   display: flex;
@@ -643,5 +662,22 @@
 }
 .enum-item input {
   flex: 1;
+}
+.add-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.enum-error {
+  color: #d55;
+  font-size: 0.8rem;
+  margin-top: 2px;
 }
 

--- a/src/theme.css
+++ b/src/theme.css
@@ -621,14 +621,14 @@ details[open] .field-summary .toggle-icon {
   margin-right: 4px;
   width: 12ch;
   height: 24px;
-  line-height: 20px;
+  line-height: 24px;
   box-sizing: border-box;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  padding: 2px 4px;
+  padding: 0 4px;
   transition: width 0.15s ease;
 }
 .schema-editor .field-summary .field-name:hover {
@@ -645,14 +645,14 @@ details[open] .field-summary .toggle-icon {
   min-width: 12ch;
   width: 12ch;
   height: 24px;
-  line-height: 20px;
+  line-height: 24px;
   box-sizing: border-box;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  padding: 2px 4px;
+  padding: 0 4px;
   transition: width 0.15s ease;
 }
 .schema-editor .field-summary .field-desc:hover {
@@ -666,13 +666,13 @@ details[open] .field-summary .toggle-icon {
 .field-summary .field-type {
   margin-left: auto;
   margin-right: 4px;
-  padding: 2px 4px;
+  padding: 0 4px;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
   color: var(--fg);
   font-size: 1rem;
-  line-height: 1;
+  line-height: 24px;
   height: 24px;
   box-sizing: border-box;
   width: auto;

--- a/src/theme.css
+++ b/src/theme.css
@@ -598,28 +598,27 @@
 }
 .field-summary {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 4px;
   cursor: pointer;
 }
 .field-summary .field-name {
   font-weight: bold;
-  flex: 0 0 auto;
-  width: 5ch;
+  flex: none;
+  width: 4ch;
   border: none;
   background: transparent;
   color: var(--fg);
   font-size: 1rem;
   padding: 2px;
-  transition: width 0.2s ease;
+  transition: width 0.15s ease;
 }
 .field-summary .field-name:hover {
   outline: 1px solid var(--accent);
 }
 .field-summary .field-name:focus {
   outline: 1px solid var(--accent);
-  width: 100%;
-  flex: 1;
+  width: 12ch;
 }
 
 .field-summary .field-type {

--- a/src/theme.css
+++ b/src/theme.css
@@ -167,6 +167,12 @@
   z-index: 10;
   min-width: 240px;
 }
+.modal-large {
+  width: 90vw;
+  max-width: 800px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
 .modal input[type="text"] {
   width: 100%;
   margin-top: 0.5rem;
@@ -209,11 +215,25 @@
   display: block;
   margin-bottom: 0.5rem;
 }
-.field-label > input,
 .field-label > select {
   display: block;
   margin-top: 0.25rem;
   width: 100%;
+  padding: 4px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.field-label > input {
+  display: block;
+  margin-top: 0.25rem;
+  width: 100%;
+  padding: 4px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
 }
 .field-label > .switch {
   display: block;
@@ -587,9 +607,21 @@
   gap: 4px;
   margin-top: 4px;
 }
-.field-body input,
 .field-body select {
   width: 100%;
+  padding: 4px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+}
+.field-body input {
+  width: 100%;
+  padding: 4px;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
 }
 .delete-btn {
   background: none;

--- a/src/theme.css
+++ b/src/theme.css
@@ -585,7 +585,7 @@
 .schema-editor ul {
   list-style: none;
   padding: 0;
-  margin: 0;
+  margin: 8px 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -617,9 +617,9 @@ details[open] .field-summary .toggle-icon {
 }
 .field-summary .field-name {
   font-weight: bold;
-  flex: 0 0 8ch;
+  flex: 0 0 auto;
   margin-right: 4px;
-  width: 8ch;
+  width: 6ch;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -631,15 +631,16 @@ details[open] .field-summary .toggle-icon {
 .field-summary .field-name:hover {
   outline: 1px solid var(--accent);
 }
-.field-summary:focus-within .field-name {
+.field-summary .field-name:focus {
   outline: 1px solid var(--accent);
-  width: 14ch;
+  width: 12ch;
 }
 
 .field-summary .field-desc {
   flex: 1 1 auto;
   margin-right: auto;
-  min-width: 16ch;
+  min-width: 12ch;
+  width: 12ch;
   border: 1px solid var(--accent);
   border-radius: 4px;
   background: var(--bg);
@@ -651,8 +652,9 @@ details[open] .field-summary .toggle-icon {
 .field-summary .field-desc:hover {
   outline: 1px solid var(--accent);
 }
-.field-summary:focus-within .field-desc {
+.field-summary .field-desc:focus {
   outline: 1px solid var(--accent);
+  width: 24ch;
 }
 
 .field-summary .field-type {
@@ -665,6 +667,7 @@ details[open] .field-summary .toggle-icon {
   color: var(--fg);
   font-size: 0.8rem;
   width: auto;
+  align-self: center;
 }
 .field-summary .delete-btn {
   margin-left: 0;

--- a/src/theme.css
+++ b/src/theme.css
@@ -602,6 +602,18 @@
   align-items: center;
   cursor: pointer;
 }
+.field-summary .field-name {
+  font-weight: bold;
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 1rem;
+  padding: 2px;
+}
+.field-summary .field-name:focus {
+  outline: 1px solid var(--accent);
+}
 .field-body {
   display: flex;
   flex-direction: column;
@@ -655,6 +667,8 @@
   padding: 0;
   display: flex;
   align-items: center;
+  justify-content: center;
+  line-height: 0;
 }
 .enum-item {
   display: flex;
@@ -676,6 +690,7 @@
   justify-content: center;
   align-self: center;
   cursor: pointer;
+  line-height: 0;
 }
 .enum-error {
   color: #d55;


### PR DESCRIPTION
## Summary
- add `SchemaEditor` component to edit JSON schema visually
- replace text inputs with the editor in Tools and Editor settings modals
- style the new schema editor

## Testing
- `npm run build`
- `npm run typecheck`
- `npm test`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_6848542cd4008327b5c41d5b8617e320