### PR TITLE
Add theme toggle in settings

### DIFF
--- a/src/components/SettingsPage.tsx
+++ b/src/components/SettingsPage.tsx
@@ -1,9 +1,23 @@
+import { useWorkflowStore } from '../store/workflowStore';
+
 export default function SettingsPage() {
+  const theme = useWorkflowStore(s => s.theme);
+  const setTheme = useWorkflowStore(s => s.setTheme);
+
+  const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');
+
   return (
     <main className="main">
       <div className="page-header">
         <h2>Settings</h2>
       </div>
+      <label className="field-label">
+        Dark Mode
+        <span className="switch">
+          <input type="checkbox" checked={theme === 'dark'} onChange={toggle} />
+          <span className="slider" />
+        </span>
+      </label>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- implement dark mode switch on Settings page

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_684884d5d1e08327a60a289570884981