### PR TITLE
Enable custom tools in agent and tool editors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ export default function App() {
   const loadWorkflow = useWorkflowStore((s) => s.loadWorkflow);
   const loadTool = useWorkflowStore((s) => s.loadTool);
   const createWorkflow = useWorkflowStore((s) => s.createWorkflow);
+  const refreshTools = useWorkflowStore(s => s.refreshToolNodes);
 
   const [page, setPage] = useState<
     'workflows' | 'editor' | 'settings' | 'tools' | 'assistants' | 'chat'
@@ -25,9 +26,12 @@ export default function App() {
   useEffect(() => {
     fetch(`${import.meta.env.BASE_URL}nodeTypes.json`)
       .then((r) => r.json())
-      .then(loadDefs)
+      .then((json) => {
+        loadDefs(json);
+        refreshTools();
+      })
       .catch((err) => console.error('Failed to load node types', err));
-  }, [loadDefs]);
+  }, [loadDefs, refreshTools]);
 
   const openWorkflow = (name: string) => {
     loadWorkflow(name);

--- a/src/components/ToolsPage.tsx
+++ b/src/components/ToolsPage.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from 'react';
 import SchemaEditor from './SchemaEditor';
 import { v4 as uuid } from 'uuid';
+import { useWorkflowStore } from '../store/workflowStore';
 import type { NodeInstance, EdgeInstance, ToolData, ToolMeta } from '../types';
 
 
 export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }) {
   const [tools, setTools] = useState<string[]>([]);
   const [query, setQuery] = useState('');
+
+  const refreshNodes = useWorkflowStore(s => s.refreshToolNodes);
 
   const [editing, setEditing] = useState<string | null>(null);
   const [metaName, setMetaName] = useState('');
@@ -17,6 +20,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
   const refresh = () => {
     const list = localStorage.getItem('tools');
     setTools(list ? JSON.parse(list) : []);
+    refreshNodes();
   };
 
   useEffect(() => {
@@ -97,6 +101,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
     list.push(name);
     localStorage.setItem('tools', JSON.stringify(list));
     setTools(list);
+    refreshNodes();
     openEdit(name);
   };
 
@@ -123,6 +128,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
     setEditing(null);
     setData(null);
     refresh();
+    refreshNodes();
   };
 
   const deleteTool = (name: string) => {
@@ -133,6 +139,7 @@ export default function ToolsPage({ onOpen }: { onOpen: (name: string) => void }
     localStorage.setItem('tools', JSON.stringify(names));
     localStorage.removeItem(`tool.${name}`);
     setTools(names);
+    refreshNodes();
   };
 
   const filtered = tools.filter(t => t.toLowerCase().includes(query.toLowerCase()));


### PR DESCRIPTION
## Summary
- expose custom tools in the node palette by adding `refreshToolNodes`
- update `App` and `ToolsPage` to load custom tool definitions
- refresh node types whenever tools are saved, renamed or deleted

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_6849debf70388327b94816e4936c1f06