### PR TITLE
Add headers field to Curl node

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -13,7 +13,7 @@
     "MCP": "Tool",
     "Curl": "Tool",
     "Webhook": "Tool",
-    "ToolArgs": null,
+    "ToolArgs": "Json",
     "Message": null
   },
   "nodes": [

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -10,7 +10,9 @@
     "OpenAIEmbeddings": "Embeddings",
     "WebSearch": "Tool",
     "Calculator": "Tool",
-    "MCP": "Tool"
+    "MCP": "Tool",
+    "Curl": "Tool",
+    "Webhook": "Tool"
   },
   "nodes": [
     {
@@ -293,6 +295,159 @@
         }
       ],
       "fields": []
+    },
+    {
+      "id": "tool.curl",
+      "name": "cURL Request",
+      "tags": ["tool", "http", "curl"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "Curl",
+          "cardinality": "many"
+        }
+      ],
+      "fields": [
+        {
+          "id": "url",
+          "label": "URL",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "method",
+          "label": "Method",
+          "type": "enum",
+          "options": ["GET", "POST", "PUT", "DELETE"],
+          "default": "GET"
+        },
+        {
+          "id": "headers",
+          "label": "Headers",
+          "type": "string",
+          "default": ""
+        }
+      ]
+    },
+    {
+      "id": "tool.webhook",
+      "name": "Webhook",
+      "tags": ["tool", "webhook"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "Webhook",
+          "cardinality": "many"
+        }
+      ],
+      "fields": [
+        {
+          "id": "url",
+          "label": "URL",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "id": "text.concat",
+      "name": "Concatenate Text",
+      "tags": ["text", "processing"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "textIn",
+          "name": "Text",
+          "direction": "input",
+          "type": "Text",
+          "cardinality": "many",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "textOut",
+          "name": "Text",
+          "direction": "output",
+          "type": "Text",
+          "cardinality": "one"
+        }
+      ],
+      "fields": [
+        {
+          "id": "delimiter",
+          "label": "Delimiter",
+          "type": "string",
+          "default": ""
+        }
+      ]
+    },
+    {
+      "id": "json.parse",
+      "name": "Parse JSON",
+      "tags": ["json", "processing"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "textIn",
+          "name": "Text",
+          "direction": "input",
+          "type": "Text",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "jsonOut",
+          "name": "Json",
+          "direction": "output",
+          "type": "Json",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "json.stringify",
+      "name": "JSON Stringify",
+      "tags": ["json", "processing"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "jsonIn",
+          "name": "Json",
+          "direction": "input",
+          "type": "Json",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "textOut",
+          "name": "Text",
+          "direction": "output",
+          "type": "Text",
+          "cardinality": "one"
+        }
+      ],
+      "fields": [
+        {
+          "id": "pretty",
+          "label": "Pretty Print",
+          "type": "bool",
+          "default": false
+        }
+      ]
     }
   ]
 }

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -12,7 +12,9 @@
     "Calculator": "Tool",
     "MCP": "Tool",
     "Curl": "Tool",
-    "Webhook": "Tool"
+    "Webhook": "Tool",
+    "ToolArgs": null,
+    "Message": null
   },
   "nodes": [
     {
@@ -159,10 +161,10 @@
       "inputs": [],
       "outputs": [
         {
-          "id": "stateOut",
-          "name": "State",
+          "id": "argsOut",
+          "name": "ToolArgs",
           "direction": "output",
-          "type": "State",
+          "type": "ToolArgs",
           "cardinality": "one",
           "required": true
         }
@@ -448,6 +450,110 @@
           "default": false
         }
       ]
+    },
+    {
+      "id": "toolargs.tojson",
+      "name": "ToolArgs to JSON",
+      "tags": ["toolargs", "json"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "argsIn",
+          "name": "ToolArgs",
+          "direction": "input",
+          "type": "ToolArgs",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "jsonOut",
+          "name": "Json",
+          "direction": "output",
+          "type": "Json",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "toolargs.totext",
+      "name": "ToolArgs to Text",
+      "tags": ["toolargs", "text"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "argsIn",
+          "name": "ToolArgs",
+          "direction": "input",
+          "type": "ToolArgs",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "textOut",
+          "name": "Text",
+          "direction": "output",
+          "type": "Text",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "toolargs.tomessage",
+      "name": "ToolArgs to Message",
+      "tags": ["toolargs", "message"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "argsIn",
+          "name": "ToolArgs",
+          "direction": "input",
+          "type": "ToolArgs",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "msgOut",
+          "name": "Message",
+          "direction": "output",
+          "type": "Message",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "state.from.message",
+      "name": "Create State from Message",
+      "tags": ["state", "message"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "msgIn",
+          "name": "Message",
+          "direction": "input",
+          "type": "Message",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "stateOut",
+          "name": "State",
+          "direction": "output",
+          "type": "State",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
     }
   ]
 }

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -452,32 +452,6 @@
       ]
     },
     {
-      "id": "toolargs.tojson",
-      "name": "ToolArgs to JSON",
-      "tags": ["toolargs", "json"],
-      "layout": "singleRow",
-      "inputs": [
-        {
-          "id": "argsIn",
-          "name": "ToolArgs",
-          "direction": "input",
-          "type": "ToolArgs",
-          "cardinality": "one",
-          "required": true
-        }
-      ],
-      "outputs": [
-        {
-          "id": "jsonOut",
-          "name": "Json",
-          "direction": "output",
-          "type": "Json",
-          "cardinality": "one"
-        }
-      ],
-      "fields": []
-    },
-    {
       "id": "toolargs.totext",
       "name": "ToolArgs to Text",
       "tags": ["toolargs", "text"],

--- a/src/logic/__tests__/pinValidation.test.ts
+++ b/src/logic/__tests__/pinValidation.test.ts
@@ -144,10 +144,14 @@ describe('validateWorkflow', () => {
   it('validates tool workflows with start and end', () => {
     const nodes: Record<string, NodeInstance> = {
       start: makeNode('tool.start', 'start'),
+      toMsg: makeNode('toolargs.tomessage', 'toMsg'),
+      toState: makeNode('state.from.message', 'toState'),
       end: makeNode('tool.end', 'end')
     };
     const edges: EdgeInstance[] = [
-      { id: 'e1', from: { uuid: 'start', pin: 'stateOut' }, to: { uuid: 'end', pin: 'stateIn' } }
+      { id: 'e1', from: { uuid: 'start', pin: 'argsOut' }, to: { uuid: 'toMsg', pin: 'argsIn' } },
+      { id: 'e2', from: { uuid: 'toMsg', pin: 'msgOut' }, to: { uuid: 'toState', pin: 'msgIn' } },
+      { id: 'e3', from: { uuid: 'toState', pin: 'stateOut' }, to: { uuid: 'end', pin: 'stateIn' } }
     ];
     expect(
       validateWorkflow(nodes, edges, nodeTypes, hierarchy, 'tool')


### PR DESCRIPTION
## Summary
- extend cURL Request node with optional headers field

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_6849e14670208327bc8a5ba6870b90da