### PR TITLE
Add collapsible categories to Node picker

### DIFF
--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -17,6 +17,7 @@
       "id": "openai.chatmodel",
       "name": "OpenAI Chat Model",
       "tags": ["llm", "openai", "chatmodel"],
+      "category": "Models",
       "layout": "singleRow",
       "inputs": [],
       "outputs": [
@@ -73,6 +74,7 @@
       "id": "openai.embeddings",
       "name": "OpenAI Embeddings",
       "tags": ["openai", "embeddings"],
+      "category": "Embeddings",
       "layout": "singleRow",
       "inputs": [],
       "outputs": [
@@ -114,6 +116,7 @@
       "id": "workflow.start",
       "name": "Start Agent",
       "tags": ["workflow", "start", "state"],
+      "category": "Workflow",
       "editors": ["agent"],
       "layout": "singleRow",
       "inputs": [],
@@ -133,6 +136,7 @@
       "id": "workflow.end",
       "name": "End Agent",
       "tags": ["workflow", "end", "state"],
+      "category": "Workflow",
       "editors": ["agent"],
       "layout": "singleRow",
       "inputs": [
@@ -152,6 +156,7 @@
       "id": "tool.start",
       "name": "Tool Start",
       "tags": ["tool", "start"],
+      "category": "Tool Workflow",
       "editors": ["tool"],
       "layout": "singleRow",
       "inputs": [],
@@ -171,6 +176,7 @@
       "id": "tool.end",
       "name": "Tool End",
       "tags": ["tool", "end"],
+      "category": "Tool Workflow",
       "editors": ["tool"],
       "layout": "singleRow",
       "inputs": [
@@ -190,6 +196,7 @@
       "id": "agent",
       "name": "Agent",
       "tags": ["agent"],
+      "category": "Workflow",
       "editors": ["agent", "tool"],
       "layout": "singleRow",
       "inputs": [
@@ -230,6 +237,7 @@
       "id": "tool.websearch",
       "name": "Web Search",
       "tags": ["tool", "web", "search"],
+      "category": "Tools",
       "layout": "singleRow",
       "inputs": [
         {
@@ -264,6 +272,7 @@
       "id": "tool.calculator",
       "name": "Calculator",
       "tags": ["tool", "math", "calculator"],
+      "category": "Tools",
       "layout": "singleRow",
       "inputs": [],
       "outputs": [
@@ -281,6 +290,7 @@
       "id": "tool.mcp",
       "name": "MCP Tool",
       "tags": ["tool", "mcp"],
+      "category": "Tools",
       "layout": "singleRow",
       "inputs": [],
       "outputs": [

--- a/public/nodeTypes.json
+++ b/public/nodeTypes.json
@@ -10,7 +10,11 @@
     "OpenAIEmbeddings": "Embeddings",
     "WebSearch": "Tool",
     "Calculator": "Tool",
-    "MCP": "Tool"
+    "MCP": "Tool",
+    "Curl": "Tool",
+    "Webhook": "Tool",
+    "ToolArgs": "Json",
+    "Message": null
   },
   "nodes": [
     {
@@ -162,10 +166,10 @@
       "inputs": [],
       "outputs": [
         {
-          "id": "stateOut",
-          "name": "State",
+          "id": "argsOut",
+          "name": "ToolArgs",
           "direction": "output",
-          "type": "State",
+          "type": "ToolArgs",
           "cardinality": "one",
           "required": true
         }
@@ -300,6 +304,237 @@
           "direction": "output",
           "type": "MCP",
           "cardinality": "many"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "tool.curl",
+      "name": "cURL Request",
+      "tags": ["tool", "http", "curl"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "Curl",
+          "cardinality": "many"
+        }
+      ],
+      "fields": [
+        {
+          "id": "url",
+          "label": "URL",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "method",
+          "label": "Method",
+          "type": "enum",
+          "options": ["GET", "POST", "PUT", "DELETE"],
+          "default": "GET"
+        },
+        {
+          "id": "headers",
+          "label": "Headers",
+          "type": "string",
+          "default": ""
+        }
+      ]
+    },
+    {
+      "id": "tool.webhook",
+      "name": "Webhook",
+      "tags": ["tool", "webhook"],
+      "layout": "singleRow",
+      "inputs": [],
+      "outputs": [
+        {
+          "id": "toolOut",
+          "name": "Tool",
+          "direction": "output",
+          "type": "Webhook",
+          "cardinality": "many"
+        }
+      ],
+      "fields": [
+        {
+          "id": "url",
+          "label": "URL",
+          "type": "string",
+          "required": true
+        }
+      ]
+    },
+    {
+      "id": "text.concat",
+      "name": "Concatenate Text",
+      "tags": ["text", "processing"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "textIn",
+          "name": "Text",
+          "direction": "input",
+          "type": "Text",
+          "cardinality": "many",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "textOut",
+          "name": "Text",
+          "direction": "output",
+          "type": "Text",
+          "cardinality": "one"
+        }
+      ],
+      "fields": [
+        {
+          "id": "delimiter",
+          "label": "Delimiter",
+          "type": "string",
+          "default": ""
+        }
+      ]
+    },
+    {
+      "id": "json.parse",
+      "name": "Parse JSON",
+      "tags": ["json", "processing"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "textIn",
+          "name": "Text",
+          "direction": "input",
+          "type": "Text",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "jsonOut",
+          "name": "Json",
+          "direction": "output",
+          "type": "Json",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "json.stringify",
+      "name": "JSON Stringify",
+      "tags": ["json", "processing"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "jsonIn",
+          "name": "Json",
+          "direction": "input",
+          "type": "Json",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "textOut",
+          "name": "Text",
+          "direction": "output",
+          "type": "Text",
+          "cardinality": "one"
+        }
+      ],
+      "fields": [
+        {
+          "id": "pretty",
+          "label": "Pretty Print",
+          "type": "bool",
+          "default": false
+        }
+      ]
+    },
+    {
+      "id": "toolargs.totext",
+      "name": "ToolArgs to Text",
+      "tags": ["toolargs", "text"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "argsIn",
+          "name": "ToolArgs",
+          "direction": "input",
+          "type": "ToolArgs",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "textOut",
+          "name": "Text",
+          "direction": "output",
+          "type": "Text",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "toolargs.tomessage",
+      "name": "ToolArgs to Message",
+      "tags": ["toolargs", "message"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "argsIn",
+          "name": "ToolArgs",
+          "direction": "input",
+          "type": "ToolArgs",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "msgOut",
+          "name": "Message",
+          "direction": "output",
+          "type": "Message",
+          "cardinality": "one"
+        }
+      ],
+      "fields": []
+    },
+    {
+      "id": "state.from.message",
+      "name": "Create State from Message",
+      "tags": ["state", "message"],
+      "layout": "singleRow",
+      "inputs": [
+        {
+          "id": "msgIn",
+          "name": "Message",
+          "direction": "input",
+          "type": "Message",
+          "cardinality": "one",
+          "required": true
+        }
+      ],
+      "outputs": [
+        {
+          "id": "stateOut",
+          "name": "State",
+          "direction": "output",
+          "type": "State",
+          "cardinality": "one"
         }
       ],
       "fields": []

--- a/src/components/EditorHeader.tsx
+++ b/src/components/EditorHeader.tsx
@@ -4,6 +4,7 @@ import SchemaEditor from './SchemaEditor';
 
 export default function EditorHeader({ onBack }: { onBack: () => void }) {
   const name = useWorkflowStore(s => s.workflowName);
+  const displayName = name.startsWith('tool:') ? name.slice(5) : name;
   const dirty = useWorkflowStore(s => s.dirty);
   const rename = useWorkflowStore(s => s.renameWorkflow);
   const toolMeta = useWorkflowStore(s => s.toolMeta);
@@ -11,7 +12,7 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
   const renameTool = useWorkflowStore(s => s.renameTool);
 
   const [editing, setEditing] = useState(false);
-  const [newName, setNewName] = useState(name);
+  const [newName, setNewName] = useState(displayName);
   const [cfgOpen, setCfgOpen] = useState(false);
   const [cfgName, setCfgName] = useState(
     toolMeta?.name || (name.startsWith('tool:') ? name.slice(5) : '')
@@ -20,7 +21,7 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
   const [cfgSchema, setCfgSchema] = useState(toolMeta?.schema || '');
 
   const startEdit = () => {
-    setNewName(name);
+    setNewName(displayName);
     setEditing(true);
   };
 
@@ -51,8 +52,12 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
   };
 
   const save = () => {
-    if (newName && newName !== name) {
-      rename(name, newName);
+    if (newName && newName !== displayName) {
+      if (name.startsWith('tool:')) {
+        renameTool(name.slice(5), newName);
+      } else {
+        rename(name, newName);
+      }
     }
     setEditing(false);
   };
@@ -81,7 +86,7 @@ export default function EditorHeader({ onBack }: { onBack: () => void }) {
           </button>
         )}
         <h2 className="editor-title">
-          {name}
+          {displayName}
           {dirty && <span className="unsaved">*</span>}
           <button
             className="name-edit-btn"

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -143,6 +143,7 @@ export default function NodePalette({ editor }: Props) {
                     {nts.map((nt) => (
                       <li
                         key={nt.id}
+                        className="palette-item"
                         draggable
                         onDragStart={(e) => {
                           e.dataTransfer.setData('application/x-node-type', nt.id);

--- a/src/components/NodePalette.tsx
+++ b/src/components/NodePalette.tsx
@@ -24,6 +24,18 @@ export default function NodePalette({ editor }: Props) {
     );
   }, [nodeTypes, query, editor]);
 
+  const grouped = useMemo(() => {
+    const map = new Map<string, typeof filtered>();
+    filtered.forEach((nt) => {
+      const cat = nt.category || 'Other';
+      if (!map.has(cat)) map.set(cat, [] as typeof filtered);
+      map.get(cat)!.push(nt);
+    });
+    return Array.from(map.entries());
+  }, [filtered]);
+
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
   return (
     <div className="palette-wrapper">
       <button
@@ -113,17 +125,35 @@ export default function NodePalette({ editor }: Props) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
-          <ul>
-            {filtered.map((nt) => (
-              <li
-                key={nt.id}
-                draggable
-                onDragStart={(e) => {
-                  e.dataTransfer.setData('application/x-node-type', nt.id);
-                }}
-              >
-                {nt.icon && <img src={nt.icon} alt="" />}
-                {nt.name}
+          <ul className="palette-list">
+            {grouped.map(([cat, nts]) => (
+              <li key={cat} className="palette-category">
+                <button
+                  type="button"
+                  className="category-header"
+                  onClick={() =>
+                    setCollapsed((c) => ({ ...c, [cat]: !c[cat] }))
+                  }
+                >
+                  <span className="arrow">{collapsed[cat] ? '▶' : '▼'}</span>
+                  {cat}
+                </button>
+                {!collapsed[cat] && (
+                  <ul className="category-items">
+                    {nts.map((nt) => (
+                      <li
+                        key={nt.id}
+                        draggable
+                        onDragStart={(e) => {
+                          e.dataTransfer.setData('application/x-node-type', nt.id);
+                        }}
+                      >
+                        {nt.icon && <img src={nt.icon} alt="" />}
+                        {nt.name}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </li>
             ))}
           </ul>

--- a/src/logic/__tests__/pinValidation.test.ts
+++ b/src/logic/__tests__/pinValidation.test.ts
@@ -144,10 +144,14 @@ describe('validateWorkflow', () => {
   it('validates tool workflows with start and end', () => {
     const nodes: Record<string, NodeInstance> = {
       start: makeNode('tool.start', 'start'),
+      toMsg: makeNode('toolargs.tomessage', 'toMsg'),
+      toState: makeNode('state.from.message', 'toState'),
       end: makeNode('tool.end', 'end')
     };
     const edges: EdgeInstance[] = [
-      { id: 'e1', from: { uuid: 'start', pin: 'stateOut' }, to: { uuid: 'end', pin: 'stateIn' } }
+      { id: 'e1', from: { uuid: 'start', pin: 'argsOut' }, to: { uuid: 'toMsg', pin: 'argsIn' } },
+      { id: 'e2', from: { uuid: 'toMsg', pin: 'msgOut' }, to: { uuid: 'toState', pin: 'msgIn' } },
+      { id: 'e3', from: { uuid: 'toState', pin: 'stateOut' }, to: { uuid: 'end', pin: 'stateIn' } }
     ];
     expect(
       validateWorkflow(nodes, edges, nodeTypes, hierarchy, 'tool')

--- a/src/store/workflowStore.ts
+++ b/src/store/workflowStore.ts
@@ -248,6 +248,7 @@ export const useWorkflowStore = create<WorkflowState>()(
             id: typeId,
             name,
             tags: ['tool', 'custom'],
+            category: 'Custom Tools',
             layout: 'singleRow',
             inputs: [],
             outputs: [

--- a/src/theme.css
+++ b/src/theme.css
@@ -98,6 +98,24 @@
   padding-left: 1rem;
   margin: 2px 0 0;
 }
+.palette-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  margin-bottom: 2px;
+  border: 1px solid #6663;
+  border-radius: 6px;
+  background: var(--bg);
+}
+.palette-item + .palette-item {
+  margin-top: 2px;
+}
+.palette-category + .palette-category {
+  border-top: 1px solid #6663;
+  padding-top: 0.5rem;
+  margin-top: 0.5rem;
+}
 .canvas { flex: 1; }
 .props {
   width: 260px;

--- a/src/theme.css
+++ b/src/theme.css
@@ -95,7 +95,7 @@
 }
 .category-items {
   list-style: none;
-  padding-left: 1rem;
+  padding-left: 0;
   margin: 2px 0 0;
 }
 .palette-item {

--- a/src/theme.css
+++ b/src/theme.css
@@ -68,6 +68,36 @@
   border: 1px solid #6663;
   border-radius: 8px;
 }
+.palette-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.palette-category {
+  list-style: none;
+  margin-bottom: 0.5rem;
+}
+.category-header {
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 2px 0;
+}
+.category-header .arrow {
+  display: inline-block;
+  width: 1em;
+  text-align: center;
+  margin-right: 4px;
+}
+.category-items {
+  list-style: none;
+  padding-left: 1rem;
+  margin: 2px 0 0;
+}
 .canvas { flex: 1; }
 .props {
   width: 260px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,8 @@ export interface NodeType {
   name: string;
   icon?: string;
   tags: string[];
+  /** Optional palette category */
+  category?: string;
   layout: 'singleRow';
   inputs: Pin[];
   outputs: Pin[];


### PR DESCRIPTION
## Summary
- add optional `category` field to `NodeType`
- categorize node definitions in `public/nodeTypes.json`
- generate custom tools with `category: "Custom Tools"`
- group palette nodes by category with collapse/expand support
- style the new UI elements

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_6849e4502f4483279063f8c264d467d4